### PR TITLE
chore(): Added stuff for claude and testing branch protection

### DIFF
--- a/.claude/CHECKLIST.md
+++ b/.claude/CHECKLIST.md
@@ -1,0 +1,116 @@
+# Tooling & Infrastructure Checklist
+
+Granular checklist for tooling, DX, and infrastructure work. Claude updates this as items are completed or added.
+
+---
+
+## Claude Code
+
+- [x] Root `CLAUDE.md` with project overview, commands, architecture, and design system references
+- [x] Package-level `CLAUDE.md` for `packages/react`, `packages/vue`, `packages/types`, `packages/website`
+- [x] Slash commands — component scaffolding (`create-react-atom`, `create-react-molecule`, `create-vue-atom`, `create-vue-molecule`)
+- [x] Slash commands — stories and hooks (`add-story`, `add-hook`, `add-composable`)
+- [x] Slash commands — Figma (`code-connect`, `sync-tokens`, `create-spec`)
+- [x] Slash commands — quality (`audit-component`, `audit-react-library`, `audit-vue-library`, `accessibility-audit`, `check-breaking-changes`)
+- [x] Slash commands — lifecycle (`pr-description`, `deprecate-react-component`, `deprecate-vue-component`)
+- [x] `.claude/settings.json` with permission allowlist and PostToolUse hooks (lint on edit, build:types on types edit)
+- [x] `.claude/specs/` with component spec template and Button spec
+- [x] Memory — Figma file URLs saved for future sessions
+
+---
+
+## Figma
+
+- [x] Figma project created (Design Tokens file + Component Library file)
+- [x] Figma MCP authenticated
+- [x] `figma/figma.config.json` scaffolded for Code Connect
+- [ ] Design tokens defined in Figma (primitives: color, spacing, typography, radii, transitions)
+- [ ] Semantic/alias token layer in Figma
+- [ ] Component Library frames created for existing components (Button, Badge, ButtonGroup)
+- [ ] Figma libraries published (Design Tokens + Component Library)
+- [ ] Code Connect published for Button
+- [ ] Code Connect published for Badge
+- [ ] Code Connect published for ButtonGroup
+
+---
+
+## Token Pipeline
+
+- [x] `tokens/` folder scaffolded
+- [ ] Style Dictionary installed and configured
+- [ ] `tokens/primitives.json` populated via `/sync-tokens`
+- [ ] Style Dictionary outputs CSS custom properties to `packages/vue/src/tokens/`
+- [ ] Style Dictionary outputs JS tokens consumed by `defaultTheme.ts`
+- [ ] Token sync validated end-to-end (Figma → `tokens/` → theme → components)
+
+---
+
+## Testing
+
+- [ ] Vitest unit test setup for `packages/react/src/hooks/`
+- [ ] Vitest unit test setup for `packages/vue/src/composables/`
+- [ ] `useButton` unit tests
+- [ ] Chromatic installed and configured (`@chromatic-com/storybook` already in devDeps)
+- [ ] Chromatic running on PRs via GitHub Actions
+- [ ] Storybook a11y switched from `'todo'` to `'error'` for all components
+
+---
+
+## ESLint
+
+- [ ] Root `eslint.config.js` (flat config, ESLint 10) covering all packages
+- [ ] `@typescript-eslint/recommended` rules for `.ts` and `.tsx` files
+- [ ] `eslint-plugin-react` + `eslint-plugin-react-hooks` for the React package
+- [ ] `eslint-plugin-vue` with `vue3-recommended` rules for the Vue package
+- [ ] Update `pnpm lint` script to remove deprecated `--ext` flag (not supported in ESLint 9+)
+- [ ] Confirm `pnpm lint` catches real errors across `packages/react`, `packages/vue`, and `packages/types`
+
+---
+
+## Git & CI
+
+- [ ] Husky installed
+- [ ] `pre-commit` hook: lint-staged (lint + format on staged files)
+- [ ] `commit-msg` hook: commitlint with conventional commits
+- [ ] `pre-push` hook: TypeScript type check
+- [ ] GitHub Actions workflow: lint → build → test on PRs
+- [ ] GitHub Actions workflow: Chromatic on PRs
+- [ ] GitHub Actions workflow: publish to npm on release
+
+---
+
+## Versioning & Publishing
+
+- [ ] Changesets installed and configured
+- [ ] `.changeset/config.json` set up for the monorepo
+- [ ] `syncpack` installed to keep dependency versions consistent
+- [ ] First alpha publish of `@molecule-ui/react` and `@molecule-ui/vue`
+
+---
+
+## Bundle Health
+
+- [ ] `size-limit` installed with per-package size budgets (`@molecule-ui/react`, `@molecule-ui/vue`)
+- [ ] Size limit check added to GitHub Actions CI (fails PR if budget exceeded)
+- [ ] `rollup-plugin-visualizer` added to Vite config for bundle composition inspection
+- [ ] Baseline bundle sizes documented after first stable release
+- [ ] Tree-shaking validated — confirm per-category imports (`@molecule-ui/react/atoms`) are smaller than full import
+
+---
+
+## Storybook Enhancements
+
+- [ ] `@storybook/addon-designs` installed — embeds Figma frames in story panels
+- [ ] Figma frame links added to all existing stories
+- [ ] Storybook deployed (Chromatic hosting or Vercel)
+
+---
+
+## Documentation Site
+
+- [ ] Site structure defined (`packages/website`)
+- [ ] Getting started / installation page
+- [ ] Component pages for all stable components
+- [ ] Design token reference page
+- [ ] Contribution guide
+- [ ] Changelog page

--- a/.claude/commands/accessibility-audit.md
+++ b/.claude/commands/accessibility-audit.md
@@ -1,0 +1,56 @@
+Audit a component for accessibility against WCAG 2.1 AA.
+
+Arguments: $ARGUMENTS
+Expected format: `<ComponentName> [react|vue]` (e.g. `Button react`)
+
+If framework is not specified, audit both if the component exists in both packages.
+
+Use Radix UI (https://www.radix-ui.com/) and the React Aria documentation (https://react-spectrum.adobe.com/react-aria/) as references for correct accessibility patterns. Cross-reference with the WAI-ARIA Authoring Practices Guide (https://www.w3.org/WAI/ARIA/apg/) for the relevant pattern (button, checkbox, dialog, etc.).
+
+---
+
+**React audit checklist**
+
+Read `<Name>.tsx`, `<Name>.types.ts`, `<Name>.styles.ts`, and `<Name>.stories.tsx` before evaluating.
+
+Semantics & ARIA:
+- [ ] Uses a semantically correct HTML element OR applies the correct `role` attribute
+- [ ] Interactive elements managed through `useButton` or the appropriate hook (not raw DOM event handlers)
+- [ ] `aria-label` or `aria-labelledby` is supported as a prop for elements without visible text
+- [ ] `aria-disabled` is set correctly when `isDisabled` is true (React Aria handles this via `buttonProps`)
+- [ ] No `aria-*` attributes hard-coded in the component that should be dynamic
+
+Keyboard:
+- [ ] All interactive functionality is reachable and operable via keyboard
+- [ ] Focus is managed correctly (React Aria hooks handle this for standard patterns)
+- [ ] Focus is not trapped unintentionally
+
+Visual:
+- [ ] Focus ring is visible on `:focus-visible` (not just `:focus`)
+- [ ] The component does not rely on color alone to convey state
+- [ ] Disabled state is visually distinct and not just color-based
+
+Props & stories:
+- [ ] `aria-label` prop is defined in types and accepted by the component
+- [ ] `data-testid` prop is defined and spread onto the root element
+- [ ] At least one story demonstrates the disabled state
+- [ ] At least one story demonstrates keyboard-accessible usage
+
+---
+
+**Vue audit checklist**
+
+Read `<Name>.vue` and `<Name>.stories.ts` before evaluating.
+
+- [ ] Uses a semantically correct HTML element OR correct `role`
+- [ ] Interactive elements use native elements (`<button>`, `<input>`) rather than `div` with click handlers
+- [ ] `aria-label` is accepted as a prop and bound to the root element
+- [ ] `aria-disabled` is set when a disabled prop is true
+- [ ] `:data-testid` is bound to the root element
+- [ ] Focus ring visible on `:focus-visible`
+- [ ] No color-only state communication
+- [ ] Stories cover disabled and interactive states
+
+---
+
+Report findings as ✅ / ❌ / ⚠️ per check. For each failure, cite the relevant WCAG 2.1 AA criterion and suggest a specific fix. Reference how Radix UI or React Aria handles the same pattern when recommending a solution.

--- a/.claude/commands/add-composable.md
+++ b/.claude/commands/add-composable.md
@@ -1,0 +1,36 @@
+Add a new Vue composable to the composables layer in the Vue package.
+
+Arguments: $ARGUMENTS
+Expected format: `<ComposableName>` using the `use` prefix (e.g. `useDisclosure`)
+
+Composables in this project encapsulate reactive logic shared across Vue components. They follow the Vue 3 Composition API `use*` convention.
+
+Follow these steps:
+
+1. **Read `packages/vue/src/composables/index.ts`** to understand what composables already exist before writing anything.
+
+2. **Create `packages/vue/src/composables/<composableName>.ts`** with:
+   - A `Use<Name>Options` type for the input parameters (if any)
+   - A `Use<Name>Return` type for the returned reactive state and methods
+   - `export function use<Name>(options?: Use<Name>Options): Use<Name>Return` — uses Vue reactivity primitives (`ref`, `computed`, `watch`, etc.) internally
+
+   Example shape:
+   ```ts
+   import { ref, computed } from 'vue'
+
+   export type Use<Name>Options = { /* ... */ }
+   export type Use<Name>Return = { /* refs, computed, methods */ }
+
+   export function use<Name>(options: Use<Name>Options = {}): Use<Name>Return {
+     // reactive logic
+     return { ... }
+   }
+   ```
+
+3. **Export from `packages/vue/src/composables/index.ts`**:
+   ```ts
+   export { use<Name> } from './<composableName>'
+   export type { Use<Name>Options, Use<Name>Return } from './<composableName>'
+   ```
+
+4. Confirm the composable file is created and the barrel is updated. Do not create a component that uses it unless asked.

--- a/.claude/commands/add-hook.md
+++ b/.claude/commands/add-hook.md
@@ -1,0 +1,25 @@
+Add a new React hook to the hooks layer in the React package.
+
+Arguments: $ARGUMENTS
+Expected format: `<HookName> [react-aria-package]` (e.g. `useCheckbox @react-aria/checkbox`)
+
+Hooks in this project are thin wrappers around React Aria primitives that expose a curated, Molecule-UI-specific API. New hooks follow the same pattern as `useButton`.
+
+Follow these steps:
+
+1. **Read `packages/react/src/hooks/useButton.ts`** to understand the established pattern before writing anything.
+
+2. **If a React Aria package is specified**, check whether it is already listed in `packages/react/package.json` dependencies. If not, note that it needs to be added — do not install it automatically.
+
+3. **Create `packages/react/src/hooks/<hookName>.ts`** with:
+   - `Use<Name>Options` type — a curated subset of the React Aria hook's options, only including what Molecule UI components will actually use
+   - `Use<Name>Return` type — the props object to spread, any state values, and the ref
+   - `export function use<Name>(options: Use<Name>Options): Use<Name>Return` — calls the React Aria hook internally, maps `options` to the aria hook's expected shape, and returns the simplified result
+
+4. **Export from `packages/react/src/hooks/index.ts`**:
+   ```ts
+   export { use<Name> } from './<hookName>'
+   export type { Use<Name>Options, Use<Name>Return } from './<hookName>'
+   ```
+
+5. Confirm the hook file is created and the barrel is updated. Do not create a component that uses it unless asked.

--- a/.claude/commands/add-story.md
+++ b/.claude/commands/add-story.md
@@ -1,0 +1,21 @@
+Add a new story variation to an existing component.
+
+Arguments: $ARGUMENTS
+Expected format: `<ComponentName> <StoryName> [react|vue]` (e.g. `Button Outlined react`)
+
+If the framework is not specified, check both packages and ask if the component exists in both.
+
+Follow these steps:
+
+1. **Locate the stories file** based on the framework:
+   - React: `packages/react/src/atoms/<lowercase>/` or `packages/react/src/molecules/<lowercase>/` → `<Name>.stories.tsx`
+   - Vue: `packages/vue/src/atoms/<lowercase>/` or `packages/vue/src/molecules/<lowercase>/` → `<Name>.stories.ts`
+
+2. **Read the existing stories file** to understand the meta definition, existing arg shapes, and which props are already covered by existing stories.
+
+3. **Add a new named export** for `<StoryName>`:
+   - React: follow the `Story = { ...Default, args: { ... }, parameters: { controls: { exclude: [...] } } }` pattern used in the file; exclude props not relevant to this variation from controls
+   - Vue: follow the `StoryObj<typeof meta>` pattern used in the file
+   - Set `args` that highlight the props most relevant to this variation
+
+4. Confirm the story is added and no existing stories were modified.

--- a/.claude/commands/audit-component.md
+++ b/.claude/commands/audit-component.md
@@ -1,0 +1,49 @@
+Audit a single component against project conventions.
+
+Arguments: $ARGUMENTS
+Expected format: `<ComponentName> [react|vue]` (e.g. `Button react`)
+
+If the framework is not specified, audit both packages if the component exists in both.
+
+---
+
+**React checklist** — `packages/react/src/atoms/<lowercase>/` or `molecules/<lowercase>/`
+
+Types (`packages/types/src/components/`):
+- [ ] Type file exists for this component
+- [ ] Includes `children: React.ReactNode`
+- [ ] Includes `'data-testid'?: string`
+- [ ] Re-exported from the category types index (`atoms/index.ts` or `molecules/index.ts`)
+
+Component files:
+- [ ] `<Name>.types.ts` imports from `@molecule-ui/types`
+- [ ] `<Name>.styles.ts` uses `$`-prefixed transient props for all styled-component-only props
+- [ ] `<Name>.styles.ts` has at least one theme token read with a fallback value
+- [ ] `<Name>.tsx` uses `React.forwardRef`
+- [ ] `<Name>.tsx` sets `<Name>.displayName = '<Name>'`
+- [ ] `<Name>.tsx` has both a named export and a default export
+- [ ] `<Name>.tsx` does not import directly from `@react-aria/*` (must go through `src/hooks/`)
+- [ ] `<Name>.tsx` spreads `data-testid` onto the root element
+- [ ] `<Name>.stories.tsx` has `title: 'Atoms/<Name>'` or `'Molecules/<Name>'` and `tags: ['autodocs']`
+- [ ] `<Name>.stories.tsx` has a `Default` story and at least one variation story per major prop
+- [ ] `index.ts` exports both the component and its prop types
+- [ ] Component is re-exported from `packages/react/src/atoms/index.ts` or `molecules/index.ts`
+
+---
+
+**Vue checklist** — `packages/vue/src/atoms/<lowercase>/` or `molecules/<lowercase>/`
+
+- [ ] Type file exists in `packages/types/src/components/` (may be shared with React)
+- [ ] `<Name>.vue` uses `<script lang="ts" setup>`
+- [ ] `<Name>.vue` uses `defineProps` + `withDefaults` and imports types from `@molecule-ui/types`
+- [ ] `<Name>.vue` includes `<slot />` for children
+- [ ] `<Name>.vue` spreads `data-testid` onto the root element
+- [ ] `<name>.css` exists with at least one CSS custom property placeholder
+- [ ] `<Name>.stories.ts` has correct title and `tags: ['autodocs']`
+- [ ] `<Name>.stories.ts` has a `Default` story and at least one variation per major prop
+- [ ] `index.ts` exports the component
+- [ ] Component is re-exported from `packages/vue/src/atoms/index.ts` or `molecules/index.ts`
+
+---
+
+Report findings as a checklist with ✅ pass / ❌ fail / ⚠️ needs attention. Summarize any issues and suggest fixes.

--- a/.claude/commands/audit-react-library.md
+++ b/.claude/commands/audit-react-library.md
@@ -1,0 +1,26 @@
+Audit all React components in the library against project conventions.
+
+No arguments needed.
+
+Follow these steps:
+
+1. **Discover all components** by reading `packages/react/src/atoms/index.ts` and `packages/react/src/molecules/index.ts` to get the full list.
+
+2. **For each component**, check the following in `packages/react/src/atoms/<lowercase>/` or `molecules/<lowercase>/`:
+
+   Types (`packages/types/src/components/`):
+   - [ ] Type file exists
+   - [ ] Includes `children: React.ReactNode` and `'data-testid'?: string`
+   - [ ] Re-exported from the category types index
+
+   Component files:
+   - [ ] `<Name>.types.ts` imports from `@molecule-ui/types`
+   - [ ] `<Name>.styles.ts` uses `$`-prefixed transient props and has at least one theme token with a fallback
+   - [ ] `<Name>.tsx` uses `React.forwardRef`, sets `displayName`, has both named and default export
+   - [ ] `<Name>.tsx` does not import directly from `@react-aria/*`
+   - [ ] `<Name>.tsx` spreads `data-testid` onto the root element
+   - [ ] `<Name>.stories.tsx` has correct title, `tags: ['autodocs']`, a `Default` story, and variation stories
+   - [ ] `index.ts` exports both the component and its types
+   - [ ] Component is in the category barrel (`atoms/index.ts` or `molecules/index.ts`)
+
+3. **Output a report** grouped by component using ✅ / ❌ / ⚠️ per check. End with a summary: total components audited, total issues found, and a consolidated list of all failures.

--- a/.claude/commands/audit-vue-library.md
+++ b/.claude/commands/audit-vue-library.md
@@ -1,0 +1,21 @@
+Audit all Vue components in the library against project conventions.
+
+No arguments needed.
+
+Follow these steps:
+
+1. **Discover all components** by reading `packages/vue/src/atoms/index.ts` and `packages/vue/src/molecules/index.ts` to get the full list.
+
+2. **For each component**, check the following in `packages/vue/src/atoms/<lowercase>/` or `molecules/<lowercase>/`:
+
+   - [ ] Type file exists in `packages/types/src/components/` (may be shared with React)
+   - [ ] `<Name>.vue` uses `<script lang="ts" setup>`
+   - [ ] `<Name>.vue` uses `defineProps` + `withDefaults` and imports types from `@molecule-ui/types`
+   - [ ] `<Name>.vue` includes `<slot />` for children
+   - [ ] `<Name>.vue` spreads `data-testid` onto the root element
+   - [ ] `<name>.css` exists with at least one CSS custom property placeholder
+   - [ ] `<Name>.stories.ts` has correct title (`Atoms/<Name>` or `Molecules/<Name>`), `tags: ['autodocs']`, a `Default` story, and at least one variation story per major prop
+   - [ ] `index.ts` exports the component
+   - [ ] Component is re-exported from `packages/vue/src/atoms/index.ts` or `molecules/index.ts`
+
+3. **Output a report** grouped by component using ✅ / ❌ / ⚠️ per check. End with a summary: total components audited, total issues found, and a consolidated list of all failures.

--- a/.claude/commands/check-breaking-changes.md
+++ b/.claude/commands/check-breaking-changes.md
@@ -1,0 +1,41 @@
+Check the current branch for semver-breaking changes against main.
+
+No arguments needed.
+
+A breaking change is anything that would require consumers to update their code after upgrading. This command identifies them so the correct semver bump (major) can be applied.
+
+Follow these steps:
+
+1. Run `git diff main..HEAD --name-only` to see which files changed.
+2. Run `git diff main..HEAD -- packages/types/src packages/react/src/index.ts packages/react/src/atoms/index.ts packages/react/src/molecules/index.ts packages/vue/src/index.ts packages/vue/src/atoms/index.ts packages/vue/src/molecules/index.ts` to see the public API diff.
+3. Run `git diff main..HEAD -- packages/react/package.json packages/vue/package.json packages/types/package.json` to check for dependency changes.
+
+**Evaluate for breaking changes in these categories:**
+
+Exports:
+- [ ] Any component, hook, composable, or type removed from a barrel export?
+- [ ] Any component renamed or moved to a different entry point?
+
+Props / types:
+- [ ] Any required prop added to an existing component? (consumers must update all usages)
+- [ ] Any existing prop removed?
+- [ ] Any prop type narrowed (e.g. `string` → `'a' | 'b'`)?
+- [ ] Any prop renamed?
+- [ ] Any token key removed or renamed in `MoleculeUITheme`?
+
+Behavior:
+- [ ] Any default prop value changed in a way that alters visual output?
+- [ ] Any change to which HTML element is rendered (affects styling and semantic expectations)?
+
+Dependencies:
+- [ ] Any peer dependency version range narrowed or bumped to a new major?
+- [ ] Any previously-optional peer dependency made required?
+
+**Output:**
+
+List every breaking change found with:
+- The file and line where the change occurs
+- Why it is breaking (what consumer code would need to change)
+- Whether it could be made non-breaking with a deprecation path instead
+
+End with a recommendation: **patch**, **minor**, or **major** bump, with a one-line justification.

--- a/.claude/commands/code-connect.md
+++ b/.claude/commands/code-connect.md
@@ -1,0 +1,30 @@
+Wire up Figma Code Connect for a React component.
+
+Arguments: $ARGUMENTS
+Expected format: `<ComponentName>` (e.g. `Button`)
+
+The Figma Component library is at: https://www.figma.com/design/wv7I1q5SbuPS4vozGd1gmR/Component-library
+
+Follow these steps:
+
+1. **Check that `@figma/code-connect` is installed** in `packages/react/package.json`. If it is not listed, note that it needs to be added (`pnpm add -D @figma/code-connect`) before this file can be published — do not install it automatically.
+
+   Also check that `figma/figma.config.json` exists — it should already be present. If not, create it pointing to the Component library URL with `"include": ["packages/react/src/**/*.figma.tsx"]`.
+
+2. **Locate the component** in `packages/react/src/atoms/<lowercase>/` or `packages/react/src/molecules/<lowercase>/`. Read `<Name>.types.ts` to understand the full prop surface.
+
+3. **Use the Figma MCP** (`get_design_context` or `get_metadata`) to find the node ID for the `<ComponentName>` component frame in the Component library file.
+
+4. **Create `<Name>.figma.tsx`** in the same folder as `<Name>.tsx`:
+   - Import `figma` from `@figma/code-connect`
+   - Import the component from `./index`
+   - Call `figma.connect(<Name>, '<figma-url-with-node-id>', { props: { ... }, example: (props) => <Name ... /> })`
+   - Map each Figma property to a code prop using:
+     - `figma.boolean()` for boolean props
+     - `figma.enum()` for variant/size unions
+     - `figma.string()` for text content
+     - `figma.children()` for nested components/slots
+
+5. **Check for a component spec** at `.claude/specs/<lowercase-name>.md`. If it exists, read it before mapping props — the spec documents which Figma properties map to which code props and may include the correct node ID.
+
+6. Confirm the file is created. Remind the user to run `npx figma connect publish` from the `figma/` directory (with `FIGMA_ACCESS_TOKEN` set in `.env`) when ready to upload mappings to Figma.

--- a/.claude/commands/create-react-atom.md
+++ b/.claude/commands/create-react-atom.md
@@ -1,0 +1,39 @@
+Create a new atom component in the React package.
+
+Arguments: $ARGUMENTS
+Expected format: `<ComponentName>` (e.g. `Avatar`)
+
+Follow these steps in order:
+
+1. **Types** — Create `packages/types/src/components/atoms/<lowercase-name>.ts`. Always include at minimum:
+   - A `children` prop typed as `React.ReactNode`
+   - A `'data-testid'?: string` prop
+   - Any relevant variant/size/boolean unions for the component
+
+   Then add `export * from './<lowercase-name>'` to `packages/types/src/components/atoms/index.ts`.
+
+2. **Component folder** — Create `packages/react/src/atoms/<lowercase-name>/` with these five files:
+
+   - `<Name>.types.ts` — import the base types from `@molecule-ui/types` and extend them into the public `<Name>Props` interface. Include `React.RefAttributes<HTMLElement>` if using forwardRef.
+
+   - `<Name>.styles.ts` — a single `Styled<Name>` Emotion `styled` component. Use `$`-prefixed transient props. Always include at least one token-backed style with a fallback, e.g.:
+     ```ts
+     font-family: ${({ theme }) => theme.typography?.fontFamily ?? 'inherit'};
+     ```
+
+   - `<Name>.tsx` — use `React.forwardRef`. Destructure all props with sensible defaults. Render a semantically appropriate HTML element (e.g. `<div>` for layout/display atoms, `<button>` for interactive ones) that passes `children` through and spreads `data-testid`. Set `<Name>.displayName = '<Name>'` at the bottom. Export as both named and default export.
+
+   - `<Name>.stories.tsx` — Storybook stories:
+     - `title: 'Atoms/<Name>'`, `tags: ['autodocs']`
+     - A `Default` story
+     - One additional story per major prop variation (e.g. each variant, each size)
+
+   - `index.ts` — barrel:
+     ```ts
+     export { default as <Name>, <Name> } from './<Name>'
+     export type { <Name>Props } from './<Name>.types'
+     ```
+
+3. **Barrel export** — Add `export * from './<lowercase-name>'` to `packages/react/src/atoms/index.ts`.
+
+4. Confirm all five files are created and the barrel is wired up. Do not run a build unless asked.

--- a/.claude/commands/create-react-molecule.md
+++ b/.claude/commands/create-react-molecule.md
@@ -1,0 +1,39 @@
+Create a new molecule component in the React package.
+
+Arguments: $ARGUMENTS
+Expected format: `<ComponentName>` (e.g. `Modal`)
+
+Molecules are composed components built from atoms. Follow these steps in order:
+
+1. **Types** — Create `packages/types/src/components/molecules/<lowercase-name>.ts`. Always include at minimum:
+   - A `children` prop typed as `React.ReactNode`
+   - A `'data-testid'?: string` prop
+   - Any relevant variant/size/boolean unions for the component
+
+   Then add `export * from './<lowercase-name>'` to `packages/types/src/components/molecules/index.ts`.
+
+2. **Component folder** — Create `packages/react/src/molecules/<lowercase-name>/` with these five files:
+
+   - `<Name>.types.ts` — import the base types from `@molecule-ui/types` and extend them into the public `<Name>Props` interface. Include `React.RefAttributes<HTMLElement>` if using forwardRef.
+
+   - `<Name>.styles.ts` — Emotion `styled` wrapper component(s). Use `$`-prefixed transient props. Always include at least one token-backed style with a fallback, e.g.:
+     ```ts
+     font-family: ${({ theme }) => theme.typography?.fontFamily ?? 'inherit'};
+     ```
+
+   - `<Name>.tsx` — import and compose atom components from `../../atoms`; use `React.forwardRef` if the component has a single root DOM node. Destructure all props with sensible defaults. Pass `children` through and spread `data-testid` onto the root element. Set `<Name>.displayName = '<Name>'` at the bottom. Export as both named and default export.
+
+   - `<Name>.stories.tsx` — Storybook stories:
+     - `title: 'Molecules/<Name>'`, `tags: ['autodocs']`
+     - A `Default` story
+     - One additional story per major prop variation (e.g. each variant, each size)
+
+   - `index.ts` — barrel:
+     ```ts
+     export { default as <Name>, <Name> } from './<Name>'
+     export type { <Name>Props } from './<Name>.types'
+     ```
+
+3. **Barrel export** — Add `export * from './<lowercase-name>'` to `packages/react/src/molecules/index.ts`.
+
+4. Confirm all five files are created and the barrel is wired up. Do not run a build unless asked.

--- a/.claude/commands/create-spec.md
+++ b/.claude/commands/create-spec.md
@@ -1,0 +1,29 @@
+Create a component spec file in `.claude/specs/`.
+
+Arguments: $ARGUMENTS
+Expected format: `<ComponentName>` (e.g. `Badge`)
+
+Spec files give Claude design intent and prop mapping context before building or connecting a component. They are read automatically by `/code-connect` and should be consulted when creating or auditing a component.
+
+Follow these steps:
+
+1. **Check if a spec already exists** at `.claude/specs/<lowercase-name>.md`. If it does, read it and report what's there — do not overwrite unless asked.
+
+2. **Read the existing component files** if the component already exists:
+   - React: `packages/react/src/atoms/<lowercase>/` or `molecules/<lowercase>/`
+   - Types: `packages/types/src/components/atoms/<lowercase>.ts` or `molecules/`
+   - Use these to populate props and states accurately rather than guessing
+
+3. **Use the Figma MCP** (`get_design_context` or `get_screenshot`) on the Component library file to find the component frame and its variants:
+   - Component library: https://www.figma.com/design/wv7I1q5SbuPS4vozGd1gmR/Component-library
+   - Capture the node ID for the component frame and include it in the Figma frame link
+
+4. **Create `.claude/specs/<lowercase-name>.md`** using `.claude/specs/_template.md` as the base. Fill in:
+   - Overview and Figma frame link with the correct node ID
+   - All props with types, defaults, and notes
+   - All visual/interactive states
+   - Anatomy (root element, slots, sub-elements)
+   - Accessibility (role, keyboard, ARIA, screen reader behavior)
+   - Any open questions or unresolved design decisions
+
+5. Confirm the spec file is created and report any sections that could not be filled in from available information.

--- a/.claude/commands/create-vue-atom.md
+++ b/.claude/commands/create-vue-atom.md
@@ -1,0 +1,34 @@
+Create a new atom component in the Vue package.
+
+Arguments: $ARGUMENTS
+Expected format: `<ComponentName>` (e.g. `Avatar`)
+
+Follow these steps in order:
+
+1. **Types** — If props for this component don't already exist in `packages/types/src/components/atoms/<lowercase-name>.ts`, create the file. Always include at minimum:
+   - A `'data-testid'?: string` prop
+   - Any relevant variant/size/boolean unions for the component
+
+   Then add `export * from './<lowercase-name>'` to `packages/types/src/components/atoms/index.ts`. Skip this step if the React atom was already created and types exist.
+
+2. **Component folder** — Create `packages/vue/src/atoms/<lowercase-name>/` with these four files:
+
+   - `<Name>.vue` — Single File Component using `<script lang="ts" setup>`. Define props with `defineProps` + `withDefaults`, importing prop types from `@molecule-ui/types`. Always include a default slot (`<slot />`) so the component accepts children. Spread `data-testid` onto the root element. Use a semantically appropriate HTML element. Apply scoped CSS classes for styling.
+
+   - `<name>.css` — scoped styles for the component. Always include at least one placeholder rule using a CSS custom property where a design token will eventually be wired in, e.g.:
+     ```css
+     .molecule-<name> {
+       font-family: var(--molecule-font-family, inherit);
+     }
+     ```
+
+   - `<Name>.stories.ts` — Storybook stories using `@storybook/vue3-vite`:
+     - `title: 'Atoms/<Name>'`, `tags: ['autodocs']`
+     - A `Default` story
+     - One additional story per major prop variation (e.g. each variant, each size)
+
+   - `index.ts` — barrel: `export { default as <Name> } from './<Name>.vue'`
+
+3. **Barrel export** — Add `export * from './<lowercase-name>'` to `packages/vue/src/atoms/index.ts`.
+
+4. Confirm all four files are created and the barrel is wired up. Do not run a build unless asked.

--- a/.claude/commands/create-vue-molecule.md
+++ b/.claude/commands/create-vue-molecule.md
@@ -1,0 +1,34 @@
+Create a new molecule component in the Vue package.
+
+Arguments: $ARGUMENTS
+Expected format: `<ComponentName>` (e.g. `Modal`)
+
+Molecules are composed components built from atoms. Follow these steps in order:
+
+1. **Types** — If props for this component don't already exist in `packages/types/src/components/molecules/<lowercase-name>.ts`, create the file. Always include at minimum:
+   - A `'data-testid'?: string` prop
+   - Any relevant variant/size/boolean unions for the component
+
+   Then add `export * from './<lowercase-name>'` to `packages/types/src/components/molecules/index.ts`. Skip this step if the React molecule was already created and types exist.
+
+2. **Component folder** — Create `packages/vue/src/molecules/<lowercase-name>/` with these four files:
+
+   - `<Name>.vue` — Single File Component using `<script lang="ts" setup>`. Import and compose atom components from `../../atoms`. Define props with `defineProps` + `withDefaults`, importing prop types from `@molecule-ui/types`. Always include a default slot (`<slot />`) so the component accepts children. Spread `data-testid` onto the root element. Apply scoped CSS classes for styling.
+
+   - `<name>.css` — scoped styles for the component. Always include at least one placeholder rule using a CSS custom property where a design token will eventually be wired in, e.g.:
+     ```css
+     .molecule-<name> {
+       font-family: var(--molecule-font-family, inherit);
+     }
+     ```
+
+   - `<Name>.stories.ts` — Storybook stories using `@storybook/vue3-vite`:
+     - `title: 'Molecules/<Name>'`, `tags: ['autodocs']`
+     - A `Default` story
+     - One additional story per major prop variation (e.g. each variant, each size)
+
+   - `index.ts` — barrel: `export { default as <Name> } from './<Name>.vue'`
+
+3. **Barrel export** — Add `export * from './<lowercase-name>'` to `packages/vue/src/molecules/index.ts`.
+
+4. Confirm all four files are created and the barrel is wired up. Do not run a build unless asked.

--- a/.claude/commands/deprecate-react-component.md
+++ b/.claude/commands/deprecate-react-component.md
@@ -1,0 +1,38 @@
+Mark a React component as deprecated.
+
+Arguments: $ARGUMENTS
+Expected format: `<ComponentName> <ReplacementComponentName>` (e.g. `OldButton NewButton`)
+If there is no replacement, use: `<ComponentName> none`
+
+Follow these steps:
+
+1. **Types** — In `packages/types/src/components/atoms/<lowercase>.ts` (or `molecules/`), add a `@deprecated` JSDoc above the relevant type exports:
+   ```ts
+   /**
+    * @deprecated Use <ReplacementComponentName> instead.
+    */
+   ```
+
+2. **`<Name>.types.ts`** — Add the same `@deprecated` JSDoc above the `<Name>Props` interface.
+
+3. **`<Name>.tsx`** — Add a dev-only deprecation warning at the top of the render function, before the return:
+   ```ts
+   if (process.env.NODE_ENV !== 'production') {
+     console.warn('[molecule-ui] <Name> is deprecated. Use <ReplacementComponentName> instead.');
+   }
+   ```
+
+4. **`<Name>.stories.tsx`** — Add `'deprecated'` to the `tags` array in the meta object. Add a deprecation notice to `parameters`:
+   ```ts
+   parameters: {
+     docs: {
+       description: {
+         component: '⚠️ **Deprecated.** Use `<ReplacementComponentName>` instead.',
+       },
+     },
+   },
+   ```
+
+5. **`index.ts`** — Add a `@deprecated` JSDoc above the component export line.
+
+6. Confirm all five locations are updated. Do not remove any files or exports — deprecated components remain in the package until the next major version.

--- a/.claude/commands/deprecate-vue-component.md
+++ b/.claude/commands/deprecate-vue-component.md
@@ -1,0 +1,41 @@
+Mark a Vue component as deprecated.
+
+Arguments: $ARGUMENTS
+Expected format: `<ComponentName> <ReplacementComponentName>` (e.g. `OldButton NewButton`)
+If there is no replacement, use: `<ComponentName> none`
+
+Follow these steps:
+
+1. **Types** — In `packages/types/src/components/atoms/<lowercase>.ts` (or `molecules/`), add a `@deprecated` JSDoc above the relevant type exports:
+   ```ts
+   /**
+    * @deprecated Use <ReplacementComponentName> instead.
+    */
+   ```
+   Skip if the type file is shared with React and was already updated there.
+
+2. **`<Name>.vue`** — In the `<script lang="ts" setup>` block, add a dev-only deprecation warning using `onMounted`:
+   ```ts
+   import { onMounted } from 'vue'
+
+   onMounted(() => {
+     if (import.meta.env.DEV) {
+       console.warn('[molecule-ui] <Name> is deprecated. Use <ReplacementComponentName> instead.')
+     }
+   })
+   ```
+
+3. **`<Name>.stories.ts`** — Add `'deprecated'` to the `tags` array in the meta object. Add a deprecation notice to `parameters`:
+   ```ts
+   parameters: {
+     docs: {
+       description: {
+         component: '⚠️ **Deprecated.** Use `<ReplacementComponentName>` instead.',
+       },
+     },
+   },
+   ```
+
+4. **`index.ts`** — Add a `@deprecated` JSDoc above the component export line.
+
+5. Confirm all four locations are updated. Do not remove any files or exports — deprecated components remain in the package until the next major version.

--- a/.claude/commands/pr-description.md
+++ b/.claude/commands/pr-description.md
@@ -1,0 +1,32 @@
+Generate a pull request title and body for the current branch.
+
+No arguments needed.
+
+Follow these steps:
+
+1. Run `git log main..HEAD --oneline` to see all commits on this branch.
+2. Run `git diff main..HEAD --stat` to see which files changed.
+3. Run `git diff main..HEAD` to read the full diff.
+
+4. Draft a PR **title** under 70 characters that describes the change type and scope, e.g.:
+   - `feat(Button): add isLoading prop and spinner`
+   - `chore: add Claude Code slash commands for component scaffolding`
+   - `fix(Badge): correct border-radius token fallback`
+
+5. Draft a PR **body** using this structure:
+
+```
+## Summary
+- <bullet summarizing what changed and why>
+- <bullet for any notable decisions or trade-offs, if applicable>
+
+## Changes
+- `<file or package>`: <what changed>
+
+## Test plan
+- [ ] `pnpm storybook:react` — verify affected stories render correctly
+- [ ] Check Controls panel for any new or changed props
+- [ ] <any other specific checks relevant to the diff>
+```
+
+6. Output the title and body so the user can copy them, and offer to run `gh pr create --title "..." --body "..."` if they want to open the PR immediately.

--- a/.claude/commands/sync-tokens.md
+++ b/.claude/commands/sync-tokens.md
@@ -1,0 +1,36 @@
+Sync design tokens from the Figma Design Tokens file into the codebase.
+
+No arguments needed.
+
+The Figma Design Tokens file is at: https://www.figma.com/design/GFCI1ypTw7ZXlKJzrfGKdz/Design-tokens
+
+The token values live in two files:
+- `packages/react/src/theme/defaultTheme.ts` — runtime token values
+- `packages/react/src/theme/theme.types.ts` — TypeScript shape of the theme
+
+Follow these steps:
+
+1. **Fetch token variables** from Figma using the MCP tool `get_variable_defs` on the Design Tokens file URL.
+
+2. **Write the raw Figma output to `tokens/primitives.json`** before making any other changes. This creates an auditable snapshot of exactly what came from Figma. If semantic/alias tokens exist as a separate collection, write those to `tokens/semantic.json`.
+
+3. **Read `defaultTheme.ts` and `theme.types.ts`** in full before making any changes.
+
+4. **Map Figma variable collections to theme keys** using this structure:
+   - Color variables → `defaultTheme.colors`
+   - Spacing variables → `defaultTheme.spacing`
+   - Typography variables → `defaultTheme.typography`
+   - Border radius variables → `defaultTheme.radii`
+   - Transition/duration variables → `defaultTheme.transitions`
+
+5. **Update `defaultTheme.ts`** with new or changed values. Rules:
+   - Do not remove existing keys — they may be referenced by components
+   - Add new keys if Figma introduces tokens that don't yet exist in the theme
+   - Flag any value changes to existing keys explicitly (these affect all components using that token)
+
+6. **Update `theme.types.ts`** only if new token categories or keys were added. Do not remove or rename existing type properties.
+
+7. **Report a diff summary**:
+   - New tokens added
+   - Existing token values changed (list old → new)
+   - Figma variables that could not be mapped to an existing theme key (flag for manual review)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm build)",
+      "Bash(pnpm build:types)",
+      "Bash(pnpm storybook:react)",
+      "Bash(pnpm storybook:vue)",
+      "Bash(pnpm dev:website)",
+      "Bash(pnpm lint)",
+      "Bash(pnpm format)",
+      "Bash(pnpm -F @molecule-ui/react vitest*)",
+      "Bash(pnpm -F @molecule-ui/vue vitest*)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,5 +11,32 @@
       "Bash(pnpm -F @molecule-ui/react vitest*)",
       "Bash(pnpm -F @molecule-ui/vue vitest*)"
     ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "matcher": "Edit|Write",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "file=$(echo \"$CLAUDE_TOOL_INPUT\" | jq -r '.file_path // empty'); if [[ \"$file\" =~ \\.(ts|tsx|vue)$ ]]; then cd /Users/mstedman/Development/projects/molecule-ui && pnpm lint \"$file\" --max-warnings=0 2>&1; fi"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file=$(echo \"$CLAUDE_TOOL_INPUT\" | jq -r '.file_path // empty'); if [[ \"$file\" == *\"packages/types/src\"* ]]; then cd/Users/mstedman/Development/projects/molecule-ui && pnpm build:types 2>&1; fi"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/specs/_template.md
+++ b/.claude/specs/_template.md
@@ -1,0 +1,46 @@
+# [ComponentName] — Component Spec
+
+> Copy this file to `.claude/specs/<component-name>.md` when speccing a new component.
+
+## Overview
+
+Brief description of what this component does and when to use it.
+
+**Figma frame:** [Component library → Atoms/ComponentName](https://www.figma.com/design/wv7I1q5SbuPS4vozGd1gmR/Component-library?node-id=REPLACE_WITH_NODE_ID)
+
+## Variants & props
+
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| `variant` | `'primary' \| 'secondary'` | `'primary'` | |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | |
+| `isDisabled` | `boolean` | `false` | |
+| `children` | `React.ReactNode` | — | Required |
+| `data-testid` | `string` | — | Optional |
+
+## States
+
+- **Default** — resting state
+- **Hover** — visual feedback on cursor enter
+- **Active / Pressed** — visual feedback while held
+- **Disabled** — non-interactive, reduced opacity or muted colors
+- **Focus** — visible focus ring on keyboard navigation
+
+## Anatomy
+
+Describe the internal structure (e.g. root element, icon slot, label, etc.).
+
+## Accessibility
+
+- Role / element:
+- Keyboard interaction:
+- ARIA attributes:
+- Screen reader behavior:
+
+## Usage notes
+
+Any constraints, dos/don'ts, or composition rules (e.g. "never nest inside another X").
+
+## Open questions
+
+Things not yet decided or pending design clarification.

--- a/.claude/specs/button.md
+++ b/.claude/specs/button.md
@@ -1,0 +1,54 @@
+# Button — Component Spec
+
+## Overview
+
+The primary interactive element. Used for actions, form submissions, and navigation triggers. Renders as a `<button>` element managed through the `useButton` React Aria hook.
+
+**Figma frame:** [Component library → Atoms/Button](https://www.figma.com/design/wv7I1q5SbuPS4vozGd1gmR/Component-library)
+
+## Variants & props
+
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| `buttonType` | `'contained' \| 'outlined' \| 'ghost'` | `'contained'` | Visual treatment |
+| `variant` | `'primary' \| 'brand' \| 'success' \| 'destructive'` | `'primary'` | Color scheme |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | |
+| `isDisabled` | `boolean` | `false` | Uses React Aria — sets `aria-disabled`, not HTML `disabled` |
+| `isLoading` | `boolean` | `false` | Shows a loading indicator; content remains rendered |
+| `fullWidth` | `boolean` | `false` | Stretches to fill container width |
+| `onPress` | `(e: PressEvent) => void` | — | React Aria press event (covers click, Enter, Space) |
+| `onPressChange` | `(isPressed: boolean) => void` | — | Called when pressed state changes |
+| `aria-label` | `string` | — | Required when button has no visible text |
+| `children` | `React.ReactNode` | — | Button label / content |
+| `data-testid` | `string` | — | |
+
+## States
+
+- **Default** — resting
+- **Hover** — background shifts to `*Hover` color token
+- **Pressed** — background shifts to `*Active` color token; tracked via `isPressed` from `useButton`
+- **Disabled** — `aria-disabled` set; cursor `not-allowed`; muted background
+- **Loading** — shows inline loading indicator alongside children
+- **Focus** — 2px `focusRing` outline, `outline-offset: 2px`, visible only on `:focus-visible`
+
+## Anatomy
+
+```
+<StyledButton>           ← <button> element
+  [loading indicator]    ← rendered when isLoading=true
+  {children}             ← button label
+</StyledButton>
+```
+
+## Accessibility
+
+- **Element:** native `<button>` — no role override needed
+- **Keyboard:** Enter and Space trigger `onPress` via React Aria
+- **Disabled:** `aria-disabled="true"` rather than HTML `disabled` — keeps element focusable for screen readers
+- **Focus ring:** visible on keyboard focus only (`:focus-visible`)
+- **Loading:** no ARIA live region yet — open question
+
+## Open questions
+
+- Should `isLoading` announce to screen readers via `aria-live`?
+- Loading indicator is currently an unstyled placeholder div — needs a real spinner component

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,3 +102,25 @@ The same pattern applies for molecules under `src/molecules/`, and for adding an
 - **React Aria**: accessibility behavior (keyboard events, press states, ARIA attributes) is handled via hooks in `src/hooks/` that wrap `@react-aria/*`. Add new hooks there rather than importing React Aria directly in components.
 - **`useButton` hook**: wraps `@react-aria/button` and returns `{ buttonProps, isPressed, buttonRef }`. The component is responsible for merging `buttonRef` with any `forwardedRef` from consumers.
 - **Types package must be built first**: the React and Vue packages import from `@molecule-ui/types` at build time via the `workspace:*` protocol.
+
+## Design System References
+
+When making decisions about component APIs, token naming, accessibility patterns, or documentation structure, consult these established design systems. Prefer patterns that are consistent across multiple systems over one-off choices.
+
+| System | URL | Reference for |
+|---|---|---|
+| **Atlassian Design System** | https://atlassian.design/ | Prop API conventions, component composition, token naming, theming API, atomic design execution, documentation patterns |
+| **Radix UI / Radix Primitives** | https://www.radix-ui.com/ | Headless accessibility patterns — especially relevant since we use React Aria for the same goals |
+| **Chakra UI** | https://chakra-ui.com/ | Token naming conventions, theming API design, prop ergonomics |
+| **Primer (GitHub)** | https://primer.style/ | Atomic design execution, documentation patterns, component API consistency |
+| **Shoelace** | https://shoelace.style/ | Framework-agnostic patterns that work across React and Vue — good reference for the dual-package approach |
+| **Polaris (Shopify)** | https://polaris.shopify.com/ | Component API design, content guidelines, accessibility standards |
+| **Material UI** | https://mui.com/ | Component API conventions, `sx` prop patterns, theming overrides |
+| **Ant Design** | https://ant.design/ | Large-scale design system organization, prop naming consistency |
+| **Carbon (IBM)** | https://carbondesignsystem.com/ | Token naming conventions, accessibility implementation, documentation |
+| **Fluent UI (Microsoft)** | https://fluent2.microsoft.design/ | Component composition patterns, accessibility at scale |
+| **Base UI** | https://base-ui.com/ | Headless/unstyled component patterns, composition primitives |
+
+### How to use these references
+
+When proposing a new component API, prop name, token name, or pattern — look at how 2–3 of the systems above handle the same problem and prefer the approach with the most consensus. If systems disagree, prefer the pattern used by Atlassian, Primer, or Radix as the primary tiebreakers for this project.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,104 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Molecule UI is a monorepo design system that publishes React and Vue component libraries. It uses `pnpm` workspaces and requires Node >=20 and pnpm >=9.
+
+## Common Commands
+
+```bash
+# Build all packages (types → react → vue, in dependency order)
+pnpm build
+
+# Build only the shared types package
+pnpm build:types
+
+# Start Storybook for React (port 6006)
+pnpm storybook:react
+
+# Start Storybook for Vue
+pnpm storybook:vue
+
+# Run tests (Storybook stories are the test suite, run via Vitest + Playwright)
+cd packages/react && pnpm vitest
+
+# Lint
+pnpm lint
+
+# Format
+pnpm format
+```
+
+> Always run `pnpm build:types` before building `@molecule-ui/react` or `@molecule-ui/vue` if you've changed anything in `packages/types`.
+
+## Architecture
+
+### Package Structure
+
+| Package | Name | Role |
+|---|---|---|
+| `packages/types` | `@molecule-ui/types` | Shared TypeScript prop types — single source of truth for all component APIs |
+| `packages/react` | `@molecule-ui/react` | React component library |
+| `packages/vue` | `@molecule-ui/vue` | Vue component library |
+| `packages/website` | `@molecule-ui/website` | Next.js documentation site |
+
+### Component Organization (Atomic Design)
+
+Components follow atomic design inside `packages/react/src/`:
+
+- `atoms/` — primitive, standalone components (Button, Badge)
+- `molecules/` — composed components built from atoms (ButtonGroup)
+- `hooks/` — thin wrappers around React Aria primitives consumed by components
+- `theme/` — `defaultTheme`, `MoleculeUITheme` type, and `MoleculeProvider`
+
+### Theme System
+
+`MoleculeProvider` (wraps Emotion's `ThemeProvider`) injects the theme into all styled components. Consumers can deep-merge overrides against the default:
+
+```tsx
+<MoleculeProvider theme={{ colors: { primary: '#8B5CF6' } }}>
+  <App />
+</MoleculeProvider>
+```
+
+Styled components access tokens via the `theme` prop. Always include a fallback value in case no provider is present:
+
+```ts
+font-family: ${({ theme }) => theme.typography?.fontFamily ?? 'inherit'};
+```
+
+The Storybook `preview.tsx` wraps all stories in `MoleculeProvider` automatically.
+
+### Type Flow
+
+Prop types are defined in `@molecule-ui/types` and imported into both framework packages. Adding a new prop value means changing it once in `packages/types/src/components/` and it propagates to React and Vue.
+
+### Build & Exports
+
+Vite builds the React package as an ES module library with three entry points (`index`, `atoms/index`, `molecules/index`) so consumers can tree-shake by category. React, React DOM, Emotion, and React Aria packages are all externalized.
+
+## Adding a New React Component
+
+1. **Add types** in `packages/types/src/components/atoms/<name>.ts`, then re-export from `packages/types/src/components/atoms/index.ts`.
+
+2. **Create the component folder** at `packages/react/src/atoms/<name>/` with these five files:
+   - `<Name>.tsx` — component using `React.forwardRef`; set `<Name>.displayName`
+   - `<Name>.styles.ts` — Emotion `styled` component; use `$`-prefixed transient props to avoid DOM leakage
+   - `<Name>.types.ts` — imports from `@molecule-ui/types` and builds the public prop interface
+   - `<Name>.stories.tsx` — Storybook stories with `title: 'Atoms/<Name>'` and `tags: ['autodocs']`
+   - `index.ts` — barrel: `export { default as <Name> } from './<Name>'` + `export type { <Name>Props }`
+
+3. **Wire up barrel exports**: add `export * from './<name>'` to `packages/react/src/atoms/index.ts`.
+
+4. **Develop** with `pnpm storybook:react`.
+
+The same pattern applies for molecules under `src/molecules/`, and for adding an entry point to `vite.config.ts` if a new top-level category is introduced.
+
+## Key Conventions
+
+- **Transient props**: prefix styled-component-only props with `$` (e.g., `$size`, `$variant`, `$isDisabled`) to prevent them from forwarding to the DOM element.
+- **React Aria**: accessibility behavior (keyboard events, press states, ARIA attributes) is handled via hooks in `src/hooks/` that wrap `@react-aria/*`. Add new hooks there rather than importing React Aria directly in components.
+- **`useButton` hook**: wraps `@react-aria/button` and returns `{ buttonProps, isPressed, buttonRef }`. The component is responsible for merging `buttonRef` with any `forwardedRef` from consumers.
+- **Types package must be built first**: the React and Vue packages import from `@molecule-ui/types` at build time via the `workspace:*` protocol.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,82 @@
 # molecule-ui
-Atomic Design inspired component library.
+
+![React](https://img.shields.io/badge/React-18%20%7C%2019-61DAFB?style=for-the-badge&logo=react&logoColor=black)
+![Vue](https://img.shields.io/badge/Vue-3-4FC08D?style=for-the-badge&logo=vuedotjs&logoColor=white)
+![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6?style=for-the-badge&logo=typescript&logoColor=white)
+![Vite](https://img.shields.io/badge/Vite-7-646CFF?style=for-the-badge&logo=vite&logoColor=white)
+![Storybook](https://img.shields.io/badge/Storybook-10-FF4785?style=for-the-badge&logo=storybook&logoColor=white)
+![Emotion](https://img.shields.io/badge/Emotion-11-C865B9?style=for-the-badge&logoColor=white)
+![pnpm](https://img.shields.io/badge/pnpm-10-F69220?style=for-the-badge&logo=pnpm&logoColor=white)
+![Node](https://img.shields.io/badge/Node-%3E%3D20-339933?style=for-the-badge&logo=nodedotjs&logoColor=white)
+![License](https://img.shields.io/badge/License-MIT-green?style=for-the-badge)
+
+A monorepo design system publishing React and Vue component libraries built on atomic design principles.
+
+## Packages
+
+| Package | Description |
+|---|---|
+| [`@molecule-ui/react`](packages/react) | React component library (Emotion + React Aria) |
+| [`@molecule-ui/vue`](packages/vue) | Vue 3 component library |
+| [`@molecule-ui/types`](packages/types) | Shared TypeScript prop types |
+| [`@molecule-ui/website`](packages/website) | Documentation site (Next.js) |
+
+## Requirements
+
+- Node >= 20
+- pnpm >= 9
+
+## Getting started
+
+```bash
+pnpm install
+```
+
+## Development
+
+```bash
+# React component development
+pnpm storybook:react        # Storybook on port 6006
+
+# Vue component development
+pnpm storybook:vue          # Storybook on port 6007
+
+# Documentation site
+pnpm dev:website
+```
+
+## Building
+
+```bash
+pnpm build                  # Build all packages (types → react → vue)
+pnpm build:types            # Build shared types package only
+```
+
+> Always run `pnpm build:types` first if you've changed anything in `packages/types`.
+
+## Linting & formatting
+
+```bash
+pnpm lint
+pnpm format
+```
+
+## Project structure
+
+```
+packages/
+  react/       # @molecule-ui/react — atoms, molecules, hooks, theme
+  vue/         # @molecule-ui/vue — atoms, molecules, composables
+  types/       # @molecule-ui/types — shared prop type definitions
+  website/     # Documentation site
+figma/         # Figma Code Connect config
+tokens/        # Raw design token exports from Figma
+```
+
+## Contributing
+
+See [`CLAUDE.md`](CLAUDE.md) for architecture details and development conventions. See [`ROADMAP.md`](ROADMAP.md) for planned work.
+
+## License
+
+MIT

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,102 @@
+# Molecule UI Roadmap
+
+High-level phases and goals for the project. Updated as priorities shift.
+
+---
+
+## Phase 1 — Foundation (current)
+
+Get the core infrastructure solid before building out the component library.
+
+- [x] Monorepo setup (pnpm workspaces, TypeScript, shared types package)
+- [x] React component library (`@molecule-ui/react`) with Emotion + React Aria
+- [x] Vue component library (`@molecule-ui/vue`)
+- [x] Storybook for React and Vue
+- [x] Claude Code tooling (slash commands, CLAUDE.md files, specs, hooks)
+- [x] Figma project created (Design Tokens + Component Library files)
+- [x] Figma Code Connect config scaffolded
+- [ ] Unit testing setup (Vitest for hooks and utilities)
+- [ ] Husky + commitlint + lint-staged
+- [ ] GitHub Actions CI pipeline (lint → build → test)
+- [ ] Changesets for monorepo versioning
+- [ ] First npm publish (alpha/beta)
+
+---
+
+## Phase 2 — Token System
+
+Establish the design token pipeline so components are tied to Figma.
+
+- [ ] Design tokens defined in Figma (primitives + semantic)
+- [ ] Style Dictionary setup to transform tokens to CSS custom properties and JS
+- [ ] `sync-tokens` workflow validated end-to-end
+- [ ] Vue package wired to CSS custom properties from token output
+- [ ] Token documentation in Storybook
+
+---
+
+## Phase 3 — Core Component Library
+
+Build out the foundational atom and molecule set.
+
+**Atoms**
+- [x] Button
+- [x] Badge
+- [ ] Icon
+- [ ] Avatar
+- [ ] Input
+- [ ] Checkbox
+- [ ] Radio
+- [ ] Toggle / Switch
+- [ ] Select
+- [ ] Tag / Chip
+- [ ] Spinner / Loader
+- [ ] Tooltip
+- [ ] Divider
+
+**Molecules**
+- [x] ButtonGroup
+- [ ] FormField (label + input + error)
+- [ ] Modal / Dialog
+- [ ] Drawer
+- [ ] Dropdown Menu
+- [ ] Popover
+- [ ] Toast / Notification
+- [ ] Tabs
+- [ ] Accordion
+- [ ] Card
+- [ ] Pagination
+- [ ] Breadcrumb
+
+---
+
+## Phase 4 — Quality & Design Collaboration
+
+- [ ] Chromatic visual regression testing on all stories
+- [ ] `@storybook/addon-designs` (Figma frames embedded in Storybook)
+- [ ] Figma Code Connect published for all core components
+- [ ] Accessibility audit passing at WCAG 2.1 AA for all components
+- [ ] `size-limit` bundle size budgets in CI
+- [ ] Component specs complete for all Phase 3 components
+
+---
+
+## Phase 5 — Documentation Site
+
+- [ ] Documentation site structure (`packages/website`)
+- [ ] Component pages with live examples, props table, usage guidelines
+- [ ] Design token reference page
+- [ ] Getting started / installation guide
+- [ ] Contribution guide
+- [ ] Changelog page (driven by Changesets)
+
+---
+
+## Backlog / Ideas
+
+- Organism-level components (data tables, page headers, navigation shells)
+- Dark mode token layer
+- Motion / animation token category
+- Breakpoint tokens for responsive components
+- Figma library published for internal design use
+- React Native package (`@molecule-ui/native`)

--- a/figma/README.md
+++ b/figma/README.md
@@ -1,0 +1,19 @@
+# figma/
+
+Figma-related configuration and assets for this project.
+
+## Files
+
+- `figma.config.json` — Figma Code Connect configuration; tells the CLI where to find `.figma.tsx` mapping files and which Figma file to publish to
+- `assets/` — any Figma-exported static assets (icons, illustrations) if needed in the future
+
+## Code Connect
+
+Code Connect files (`<Name>.figma.tsx`) live alongside their component in the source tree, not here. This directory holds only the config.
+
+To publish mappings to Figma after creating Code Connect files:
+```bash
+FIGMA_ACCESS_TOKEN=your_token npx figma connect publish
+```
+
+The token should be set in `.env` (already gitignored) — never commit it.

--- a/figma/figma.config.json
+++ b/figma/figma.config.json
@@ -1,0 +1,12 @@
+{
+  "codeConnect": {
+    "include": [
+      "packages/react/src/**/*.figma.tsx"
+    ],
+    "exclude": [
+      "**/node_modules/**",
+      "**/dist/**"
+    ],
+    "figmaFileUrl": "https://www.figma.com/design/wv7I1q5SbuPS4vozGd1gmR/Component-library"
+  }
+}

--- a/packages/react/CLAUDE.md
+++ b/packages/react/CLAUDE.md
@@ -1,0 +1,67 @@
+# packages/react — @molecule-ui/react
+
+React component library package. See the root `CLAUDE.md` for monorepo-wide conventions. This file covers React-specific implementation details.
+
+## Stack
+
+- **React 18/19** with `React.forwardRef` for all components that expose a DOM ref
+- **Emotion** (`@emotion/react`, `@emotion/styled`) for CSS-in-JS; `jsxImportSource` is set to `@emotion/react` in `vite.config.ts` so the JSX pragma is automatic
+- **React Aria** (`@react-aria/*`, `@react-types/*`) for accessible interaction behavior — always consumed through wrappers in `src/hooks/`, never imported directly in components
+- **Storybook 10** with `@storybook/react-vite`; all stories are wrapped in `MoleculeProvider` via the global decorator in `.storybook/preview.tsx`
+
+## Hook pattern
+
+Every React Aria behavior lives in `src/hooks/` as a thin wrapper that narrows the API to only what Molecule UI exposes. New hooks follow this shape:
+
+```ts
+// src/hooks/useExample.ts
+export type UseExampleOptions = { /* curated subset of react-aria options */ }
+export type UseExampleReturn = { /* props to spread, state values, ref */ }
+export function useExample(options: UseExampleOptions): UseExampleReturn { ... }
+```
+
+Export the hook and its types from `src/hooks/index.ts`. Components import from `../../hooks`, never from `@react-aria/*` directly.
+
+### `useButton`
+
+Returns `{ buttonProps, isPressed, buttonRef }`.
+
+The component must merge `buttonRef` (internal, for React Aria) with the consumer's `forwardedRef` manually — React Aria needs its own ref to manage focus and press events:
+
+```tsx
+ref={(node) => {
+  (buttonRef as React.MutableRefObject<HTMLElement | null>).current = node;
+  if (typeof forwardedRef === 'function') forwardedRef(node);
+  else if (forwardedRef) forwardedRef.current = node;
+}}
+```
+
+## Emotion conventions
+
+- Styled components go in `<Name>.styles.ts`, exported as `Styled<Name>`
+- Props passed only to the styled component (not forwarded to DOM) must be prefixed with `$` (transient props)
+- Always read theme tokens with optional chaining and a hard-coded fallback so the component works without `MoleculeProvider`:
+  ```ts
+  color: ${({ theme }) => theme.colors?.primary ?? '#2563EB'};
+  ```
+- The full theme shape is in `src/theme/theme.types.ts`; the default values are in `src/theme/defaultTheme.ts`
+
+## Theme / MoleculeProvider
+
+`MoleculeProvider` deep-merges a partial theme override into `defaultTheme` and passes the result to Emotion's `ThemeProvider`. Consumers only need to wrap once at the app root.
+
+The Storybook `preview.tsx` wraps all stories in `MoleculeProvider` with no overrides so every story gets the default theme.
+
+A11y checks are configured as `test: 'todo'` in Storybook — violations appear in the test UI but don't fail CI yet.
+
+## Build output
+
+Vite builds to `dist/` as an ES module with `preserveModules` (one output file per source file). Three entry points are declared in `vite.config.ts`:
+
+- `index` → `src/index.ts`
+- `atoms/index` → `src/atoms/index.ts`
+- `molecules/index` → `src/molecules/index.ts`
+
+All peer dependencies are externalized: `react`, `react-dom`, `react/jsx-runtime`, all `@emotion/*`, all `@react-aria/*`, all `@react-stately/*`.
+
+Run `pnpm build:types` (from repo root) first if `packages/types` changed, then `pnpm -F @molecule-ui/react build`.

--- a/packages/types/CLAUDE.md
+++ b/packages/types/CLAUDE.md
@@ -1,0 +1,48 @@
+# packages/types — @molecule-ui/types
+
+Shared TypeScript types package. This is the single source of truth for all component prop types — both `@molecule-ui/react` and `@molecule-ui/vue` import from here.
+
+## Purpose
+
+Centralizing types here means:
+- A prop value (e.g. a new `ButtonVariant`) is added once and propagates to both framework packages automatically
+- The type surface is auditable in one place
+- Consumers who use both packages get consistent types
+
+## File conventions
+
+One file per component, named lowercase, matching the component name:
+
+```
+src/components/
+  atoms/
+    button.ts      ← ButtonType, ButtonVariant, ButtonSize, etc.
+    badge.ts
+    index.ts       ← re-exports all atom types
+  molecules/
+    button-group.ts
+    index.ts
+  index.ts         ← re-exports atoms + molecules
+```
+
+## Adding types for a new component
+
+1. Create `src/components/atoms/<name>.ts` (or `molecules/`)
+2. Export all union types and standalone types needed by the component
+3. Add `export * from './<name>'` to the category `index.ts`
+4. Run `pnpm build:types` from the repo root before building `@molecule-ui/react` or `@molecule-ui/vue`
+
+## Build order
+
+This package **must be built first**. Both `@molecule-ui/react` and `@molecule-ui/vue` reference it via `workspace:*` and resolve the built `dist/` at build time. If you skip this step, downstream builds will fail with missing type errors.
+
+```bash
+pnpm build:types          # build this package
+pnpm build                # builds types → react → vue in order
+```
+
+## What does NOT belong here
+
+- Component implementation logic
+- React or Vue-specific types (e.g. `React.ReactNode`) — those are declared in the framework package's `.types.ts` file, which imports the shared unions from here and extends them
+- Theme types — those live in `packages/react/src/theme/theme.types.ts`

--- a/packages/vue/CLAUDE.md
+++ b/packages/vue/CLAUDE.md
@@ -1,0 +1,96 @@
+# packages/vue — @molecule-ui/vue
+
+Vue 3 component library package. See the root `CLAUDE.md` for monorepo-wide conventions. This file covers Vue-specific implementation details.
+
+## Stack
+
+- **Vue 3** with `<script lang="ts" setup>` (Composition API) for all components
+- **Plain CSS** (scoped, per-component `.css` files) — no Emotion or CSS-in-JS; design tokens will be wired via CSS custom properties
+- **Storybook 10** with `@storybook/vue3-vite`; runs on port **6007**
+- **Vite** with `@vitejs/plugin-vue`
+
+## Component pattern
+
+Every component is a Single File Component (`.vue`) using `<script lang="ts" setup>`:
+
+```vue
+<template>
+  <div :data-testid="dataTestid" class="molecule-name">
+    <slot />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import type { NameProp } from '@molecule-ui/types'
+
+withDefaults(defineProps<{
+  variant?: NameVariant
+  'data-testid'?: string
+}>(), {
+  variant: 'default',
+})
+</script>
+```
+
+Rules:
+- Always include `<slot />` — Vue's equivalent of `children`
+- Always spread `data-testid` onto the root element (use `:data-testid="dataTestid"` after destructuring or bind directly)
+- Import prop type unions from `@molecule-ui/types` — do not redeclare them locally
+- Use `withDefaults` to document and enforce default prop values
+
+## CSS conventions
+
+Each component has a `<name>.css` file imported in the `.vue` file. Use BEM-style class names prefixed with `molecule-`:
+
+```css
+.molecule-button {
+  font-family: var(--molecule-font-family, inherit);
+  /* other styles */
+}
+```
+
+CSS custom properties (`--molecule-*`) are placeholders for future design token wiring. Always include a sensible fallback value as the second argument to `var()`.
+
+There is no theme provider in the Vue package yet. Tokens will be injected via CSS custom properties at the root level when the token system is ready.
+
+## Composables
+
+Shared logic lives in `src/composables/`. Follow Vue's `use` prefix convention:
+
+```ts
+// src/composables/useExample.ts
+export function useExample(options: UseExampleOptions) {
+  // reactive logic
+  return { ... }
+}
+```
+
+Export composables from `src/composables/index.ts`.
+
+## Storybook
+
+Stories are `.stories.ts` files (not `.tsx`). Import types from `@storybook/vue3-vite`:
+
+```ts
+import type { Meta, StoryObj } from '@storybook/vue3-vite'
+import { ComponentName } from '.'
+
+const meta = {
+  component: ComponentName,
+  title: 'Atoms/ComponentName',
+  tags: ['autodocs'],
+} satisfies Meta<typeof ComponentName>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = { args: { ... } }
+```
+
+A11y checks are configured as `test: 'todo'` — violations appear in the test UI but don't fail CI yet.
+
+## Build output
+
+Same structure as the React package: ES module, `preserveModules`, three entry points (`index`, `atoms/index`, `molecules/index`). `vue` is externalized as a peer dependency.
+
+Run `pnpm build:types` first if `packages/types` changed, then `pnpm -F @molecule-ui/vue build`.

--- a/packages/website/CLAUDE.md
+++ b/packages/website/CLAUDE.md
@@ -1,0 +1,20 @@
+# packages/website — @molecule-ui/website
+
+Next.js documentation and playground site for Molecule UI. Currently a dev playground; will become the public-facing component docs site.
+
+## Stack
+
+- **Next.js** (App Router, `src/app/`)
+- Imports components from `@molecule-ui/react` via the workspace
+
+## Running
+
+```bash
+pnpm dev:website    # from repo root — starts Next.js dev server
+```
+
+## Notes
+
+- This package has its own `pnpm-lock.yaml` and `pnpm-workspace.yaml` — it is a nested workspace. Don't confuse it with the root workspace.
+- It consumes `@molecule-ui/react` as a dependency. If you change the React package and want to see changes reflected here, run `pnpm -F @molecule-ui/react build` first.
+- The site is not yet structured for production docs. When building out documentation pages, look at **Primer** (https://primer.style/) and **Atlassian Design System** (https://atlassian.design/) as references for how to structure component documentation pages.

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -1,0 +1,21 @@
+# tokens/
+
+Raw design token exports from the Figma Design Tokens file. This is the source of truth for what came directly from Figma, before any transformation into code.
+
+## Structure
+
+```
+tokens/
+  primitives.json    ← raw color, spacing, typography, radii, transition values
+  semantic.json      ← role-based tokens (e.g. color.action.primary) when added
+```
+
+## Workflow
+
+1. `/sync-tokens` fetches variables from Figma and writes raw output here
+2. The command then maps the values into `packages/react/src/theme/defaultTheme.ts`
+3. If token structure changes in Figma, this file reflects it — diff it to understand what changed
+
+## Do not hand-edit these files
+
+These are generated from Figma. Manual edits will be overwritten on the next sync. If a value looks wrong, fix it in the Figma Design Tokens file and re-sync.


### PR DESCRIPTION
## Description

Sets up the full developer tooling and documentation foundation for the molecule-ui design system — including Claude Code slash commands, project instructions, Figma integration
scaffolding, and a living roadmap and checklist.

## Work done

- Claude Code slash commands (18 total) — component scaffolding for React and Vue atoms/molecules, story and hook/composable generation, Figma Code Connect wiring, audit tools for
individual components and the full library, accessibility audit, breaking change checker, deprecation, and PR description generation
- CLAUDE.md files — root-level project instructions plus package-level context for react, vue, types, and website; includes architecture overview, conventions, design system references (11
systems), and Figma file URLs
- Component specs — .claude/specs/ with a reusable template and a populated Button spec; read automatically by the code-connect and create-spec commands
- Figma integration — figma/figma.config.json for Code Connect config; tokens/ folder for raw Figma variable exports; sync-tokens command writes here before updating defaultTheme.ts
- Settings and hooks — .claude/settings.json with a Bash permission allowlist and PostToolUse hooks that auto-lint on file edits and auto-build types when packages/types changes
- README — updated with stack badges, package table, commands, and project structure
- ROADMAP.md — five-phase roadmap from foundation through documentation site
- CHECKLIST.md — granular infrastructure checklist covering Claude tooling, Figma, token pipeline, testing, ESLint, CI, versioning, bundle health, and Storybook