### PR TITLE
feat: align Button and Badge component API with industry conventions

### DIFF
--- a/.claude/CHECKLIST.md
+++ b/.claude/CHECKLIST.md
@@ -27,7 +27,9 @@ Granular checklist for tooling, DX, and infrastructure work. Claude updates this
 - [x] Design tokens defined in Figma (primitives: color, spacing, typography, radii, transitions)
 - [x] Semantic/alias token layer in Figma
 - [ ] Component Library frames created for existing components (Button, Badge, ButtonGroup)
-- [ ] Figma libraries published (Design Tokens + Component Library)
+- [x] Component API aligned with industry conventions (Button + Badge prop rename)
+- [x] Figma library published — Design Tokens file
+- [ ] Figma library published — Component Library file
 - [ ] Code Connect published for Button
 - [ ] Code Connect published for Badge
 - [ ] Code Connect published for ButtonGroup

--- a/packages/react/src/atoms/badge/Badge.stories.tsx
+++ b/packages/react/src/atoms/badge/Badge.stories.tsx
@@ -8,29 +8,19 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
-  //   argTypes: {
-  //     buttonType: {
-  //       control: 'inline-radio',
-  //       options: ['contained', 'outlined', 'ghost'],
-  //     },
-  //     variant: {
-  //       control: 'inline-radio',
-  //       options: ['primary', 'brand', 'success', 'destructive'],
-  //     },
-  //     children: {
-  //       control: 'text',
-  //     },
-  //     size: {
-  //       control: 'inline-radio',
-  //       options: ['sm', 'md', 'lg'],
-  //     },
-  //     isLoading: {
-  //       control: 'boolean',
-  //     },
-  //     isDisabled: { control: 'boolean' },
-  //     fullWidth: { control: 'boolean' },
-  //     // onPress: { action: 'pressed' },
-  //   },
+  argTypes: {
+    intent: {
+      control: 'inline-radio',
+      options: ['neutral', 'primary', 'success', 'danger', 'brand'],
+    },
+    size: {
+      control: 'inline-radio',
+      options: ['sm', 'md', 'lg'],
+    },
+    content: {
+      control: 'text',
+    },
+  },
 } satisfies Meta<typeof Badge>;
 
 export default meta;
@@ -39,13 +29,34 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   render: (args) => <Badge {...args} />,
   args: {
-    status: 'primary',
+    intent: 'neutral',
     size: 'md',
-    content: 'Weeee',
+    content: 'Badge',
   },
-  //   parameters: {
-  //     controls: {
-  //       exclude: ['fullWidth', 'aria-label', 'data-testid'],
-  //     },
-  //   },
+};
+
+export const Intent: Story = {
+  ...Default,
+  args: {
+    intent: 'primary',
+    content: 'Badge',
+  },
+  parameters: {
+    controls: {
+      exclude: ['size'],
+    },
+  },
+};
+
+export const Size: Story = {
+  ...Default,
+  args: {
+    size: 'sm',
+    content: 'Badge',
+  },
+  parameters: {
+    controls: {
+      exclude: ['intent'],
+    },
+  },
 };

--- a/packages/react/src/atoms/badge/Badge.styles.ts
+++ b/packages/react/src/atoms/badge/Badge.styles.ts
@@ -1,50 +1,52 @@
-import styled from "@emotion/styled";
-import type { BadgeStatus, BadgeSize } from "@molecule-ui/types";
+import styled from '@emotion/styled';
+import type { BadgeIntent, BadgeSize } from '@molecule-ui/types';
 
-const sizeStyles: Record<BadgeSize, {
+const sizeStyles: Record<
+  BadgeSize,
+  {
     padding: string;
-}> = {
-    sm: {
-        padding: '4px 8px'
-    },
-    md: {
-        padding: '8px 12px'
-    },
-    lg: {
-        padding: '12px 16px'
-    }
-}
+  }
+> = {
+  sm: {
+    padding: '4px 8px',
+  },
+  md: {
+    padding: '8px 12px',
+  },
+  lg: {
+    padding: '12px 16px',
+  },
+};
 
-const statusColors: Record<BadgeStatus, { background: string; border: string; text: string }> = {
-    default: { background: '#EFF6FF', border: '#2563EB', text: '#FFFFFF' },
-    primary: { background: '#EFF6FF', border: '#2563EB', text: '#FFFFFF' },
-    success: { background: '#F0FDF4', border: '#00A63E', text: '#FFFFFF' },
-    error: { background: '#FEF2F2', border: '#DC2626', text: '#FFFFFF' },
-    info: { background: '#EFF6FF', border: '#2563EB', text: '#FFFFFF' },
+const intentColors: Record<BadgeIntent, { background: string; border: string; text: string }> = {
+  neutral: { background: '#F8FAFC', border: '#CBD5E1', text: '#475569' },
+  primary: { background: '#EFF6FF', border: '#2563EB', text: '#1D4ED8' },
+  success: { background: '#F0FDF4', border: '#00A63E', text: '#008236' },
+  danger: { background: '#FEF2F2', border: '#DC2626', text: '#B91C1C' },
+  brand: { background: '#FFF7ED', border: '#FE9A00', text: '#C27A00' },
 };
 
 const StyledBadge = styled.span<{
-    $status: BadgeStatus;
-    $size: BadgeSize;
-}>(({ theme, $status, $size }) => {
-    const status = statusColors[$status];
-    const size = sizeStyles[$size];
+  $intent: BadgeIntent;
+  $size: BadgeSize;
+}>(({ theme, $intent, $size }) => {
+  const intent = intentColors[$intent];
+  const size = sizeStyles[$size];
 
-    return {
-        fontFamily: theme?.typography?.fontFamily ?? 'inherit',
-        backgroundColor: status.background,
-        // border: `1px solid ${status.border}`,
-        border: 'none',
-        color: theme ? theme.colors.primary : status.text,
-        padding: size.padding,
-        borderRadius: '6px',
-        display: 'inline-flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        textDecoration: 'none',
-        cursor: 'default',
-        lineHeight: '1.25',
-    };
+  return {
+    fontFamily: theme?.typography?.fontFamily ?? 'inherit',
+    backgroundColor: intent.background,
+    border: 'none',
+    color: intent.text,
+    padding: size.padding,
+    borderRadius: '6px',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    textDecoration: 'none',
+    cursor: 'default',
+    lineHeight: '1.25',
+  };
 });
 
-export default StyledBadge
+export default StyledBadge;

--- a/packages/react/src/atoms/badge/Badge.tsx
+++ b/packages/react/src/atoms/badge/Badge.tsx
@@ -1,9 +1,9 @@
 import type { BadgeProps } from './Badge.types';
 import StyledBadge from './Badge.styles';
 
-const Badge = ({ status = 'primary', content, size = 'md' }: BadgeProps) => {
+const Badge = ({ intent = 'neutral', content, size = 'md' }: BadgeProps) => {
   return (
-    <StyledBadge $status={status} $size={size}>
+    <StyledBadge $intent={intent} $size={size}>
       {content}
     </StyledBadge>
   );

--- a/packages/react/src/atoms/badge/Badge.types.ts
+++ b/packages/react/src/atoms/badge/Badge.types.ts
@@ -1,9 +1,9 @@
-import type { BadgeProps as BadgePropsType } from "@molecule-ui/types";
+import type { BadgeProps as BadgePropsType } from '@molecule-ui/types';
 
 export type BadgeProps = {
-    status?: BadgePropsType['status'];
-    size?: BadgePropsType['size'];
-    content: string;
-    className?: string;
-    testId?: string;
-}
+  intent?: BadgePropsType['intent'];
+  size?: BadgePropsType['size'];
+  content: string;
+  className?: string;
+  testId?: string;
+};

--- a/packages/react/src/atoms/button/Button.stories.tsx
+++ b/packages/react/src/atoms/button/Button.stories.tsx
@@ -9,13 +9,13 @@ const meta = {
     layout: 'centered',
   },
   argTypes: {
-    buttonType: {
-      control: 'inline-radio',
-      options: ['contained', 'outlined', 'ghost'],
-    },
     variant: {
       control: 'inline-radio',
-      options: ['primary', 'brand', 'success', 'destructive'],
+      options: ['solid', 'outline', 'ghost'],
+    },
+    intent: {
+      control: 'inline-radio',
+      options: ['primary', 'success', 'danger', 'brand'],
     },
     children: {
       control: 'text',
@@ -29,7 +29,6 @@ const meta = {
     },
     isDisabled: { control: 'boolean' },
     fullWidth: { control: 'boolean' },
-    // onPress: { action: 'pressed' },
   },
 } satisfies Meta<typeof Button>;
 
@@ -39,8 +38,8 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   render: (args) => <Button {...args} />,
   args: {
-    buttonType: 'contained',
-    variant: 'primary',
+    variant: 'solid',
+    intent: 'primary',
     size: 'md',
     children: 'Button',
     isLoading: false,
@@ -53,16 +52,16 @@ export const Default: Story = {
   },
 };
 
-export const Type: Story = {
+export const Variant: Story = {
   ...Default,
   args: {
-    buttonType: 'contained',
+    variant: 'solid',
     children: 'Button',
   },
   parameters: {
     controls: {
       exclude: [
-        'variant',
+        'intent',
         'size',
         'fullWidth',
         'isDisabled',
@@ -74,16 +73,16 @@ export const Type: Story = {
   },
 };
 
-export const Variant: Story = {
+export const Intent: Story = {
   ...Default,
   args: {
-    variant: 'primary',
+    intent: 'primary',
     children: 'Button',
   },
   parameters: {
     controls: {
       exclude: [
-        'buttonType',
+        'variant',
         'size',
         'fullWidth',
         'isDisabled',
@@ -145,8 +144,8 @@ export const Disabled: Story = {
     controls: {
       exclude: [
         'children',
-        'buttonType',
         'variant',
+        'intent',
         'size',
         'fullWidth',
         'isLoading',
@@ -156,17 +155,3 @@ export const Disabled: Story = {
     },
   },
 };
-
-/**
- * All variants side by side — useful for visual comparison.
- */
-// export const AllVariants: Story = {
-//   render: () => (
-//     <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
-//       <Button variant="primary" onPress={() => {}}>Primary</Button>
-//       <Button variant="secondary" onPress={() => {}}>Secondary</Button>
-//       <Button variant="danger" onPress={() => {}}>Danger</Button>
-//       <Button variant="ghost" onPress={() => {}}>Ghost</Button>
-//     </div>
-//   ),
-// };

--- a/packages/react/src/atoms/button/Button.styles.ts
+++ b/packages/react/src/atoms/button/Button.styles.ts
@@ -1,11 +1,14 @@
-import styled from '@emotion/styled'
-import type { ButtonType, ButtonVariant, ButtonSize } from '@molecule-ui/types'
+import styled from '@emotion/styled';
+import type { ButtonVariant, ButtonIntent, ButtonSize } from '@molecule-ui/types';
 
-const sizeStyles: Record<ButtonSize, {
-  padding: string;
-  fontSize: string;
-  minHeight: string;
-}> = {
+const sizeStyles: Record<
+  ButtonSize,
+  {
+    padding: string;
+    fontSize: string;
+    minHeight: string;
+  }
+> = {
   sm: {
     padding: '6px 12px',
     fontSize: '0.875rem',
@@ -24,8 +27,8 @@ const sizeStyles: Record<ButtonSize, {
 };
 
 export const StyledButton = styled.button<{
-  $buttonType: ButtonType;
   $variant: ButtonVariant;
+  $intent: ButtonIntent;
   $size: ButtonSize;
   $isPressed: boolean;
   $isDisabled: boolean;
@@ -44,9 +47,10 @@ export const StyledButton = styled.button<{
   font-weight: ${({ theme }) => theme.typography?.fontWeight?.medium ?? 500};
   line-height: ${({ theme }) => theme.typography?.lineHeight?.tight ?? '1.25'};
   border-radius: ${({ theme }) => theme.radii?.md ?? '6px'};
-  transition: background-color ${({ theme }) => theme.transitions?.fast ?? '120ms ease'},
-              box-shadow ${({ theme }) => theme.transitions?.fast ?? '120ms ease'},
-              opacity ${({ theme }) => theme.transitions?.fast ?? '120ms ease'};
+  transition:
+    background-color ${({ theme }) => theme.transitions?.fast ?? '120ms ease'},
+    box-shadow ${({ theme }) => theme.transitions?.fast ?? '120ms ease'},
+    opacity ${({ theme }) => theme.transitions?.fast ?? '120ms ease'};
 
   /* Size */
   padding: ${({ $size }) => sizeStyles[$size].padding};
@@ -56,9 +60,8 @@ export const StyledButton = styled.button<{
   /* Full width */
   width: ${({ $fullWidth }) => ($fullWidth ? '100%' : 'auto')};
 
-  /* Variant colors */
-  ${({ theme, $variant, $isPressed, $isDisabled, $buttonType }) => {
-    // Fallback colors in case there's no theme provider
+  /* Intent + variant colors */
+  ${({ theme, $variant, $intent, $isPressed, $isDisabled }) => {
     const colors = theme.colors ?? {
       primary: '#2563EB',
       primaryHover: '#1D4ED8',
@@ -67,16 +70,18 @@ export const StyledButton = styled.button<{
       success: '#00A63E',
       successHover: '#008236',
       successActive: '#016630',
-      destructive: '#DC2626',
-      destructiveHover: '#B91C1C',
-      destructiveActive: '#991B1B',
-      textPrimary: '#0F172A',
+      successLight: '#F0FDF4',
+      danger: '#DC2626',
+      dangerHover: '#B91C1C',
+      dangerActive: '#991B1B',
+      dangerLight: '#FEF2F2',
+      brand: '#FE9A00',
+      brandHover: '#E08800',
+      brandActive: '#C27A00',
+      brandLight: '#FFF7ED',
       textOnPrimary: '#FFFFFF',
-      textSuccess: '#00A63E',
-      textOnDanger: '#FFFFFF',
       textDisabled: '#94A3B8',
-      disabled: '#2188ef',
-      border: '#E2E8F0',
+      disabled: '#CBD5E1',
       focusRing: 'rgba(37, 99, 235, 0.4)',
     };
 
@@ -88,59 +93,62 @@ export const StyledButton = styled.button<{
       `;
     }
 
-    const variantColors: Record<ButtonVariant, {
-      base: string;
-      hover: string;
-      active: string;
-      light: string;
-      contrastText: string;
-    }> = {
+    const intentColors: Record<
+      ButtonIntent,
+      {
+        base: string;
+        hover: string;
+        active: string;
+        light: string;
+        contrastText: string;
+      }
+    > = {
       primary: {
         base: colors.primary,
         hover: colors.primaryHover,
         active: colors.primaryActive,
         light: colors.primaryLight,
-        contrastText: colors.textOnPrimary
+        contrastText: colors.textOnPrimary,
       },
       success: {
         base: colors.success,
         hover: colors.successHover,
         active: colors.successActive,
         light: colors.successLight,
-        contrastText: colors.textOnPrimary
+        contrastText: colors.textOnPrimary,
       },
-      destructive: {
+      danger: {
         base: colors.danger,
         hover: colors.dangerHover,
         active: colors.dangerActive,
         light: colors.dangerLight,
-        contrastText: colors.textOnPrimary
+        contrastText: colors.textOnPrimary,
       },
       brand: {
         base: colors.brand,
         hover: colors.brandHover,
         active: colors.brandActive,
         light: colors.brandLight,
-        contrastText: colors.textOnPrimary
-      }
-    }
+        contrastText: colors.textOnPrimary,
+      },
+    };
 
-    const c = variantColors[$variant]
+    const c = intentColors[$intent];
 
-    const typeStyles: Record<ButtonType, string> = {
-      contained: `
+    const variantStyles: Record<ButtonVariant, string> = {
+      solid: `
         background: ${$isPressed ? c.active : c.base};
         color: ${c.contrastText};
         &:hover:not(:disabled) {
-          background: ${c.hover}
+          background: ${c.hover};
         }
       `,
-      outlined: `
-        background: ${$isPressed ? `${c.light}14` : `${c.light}`};
+      outline: `
+        background: ${$isPressed ? `${c.light}` : 'transparent'};
         color: ${c.base};
-        border: 1px soild ${c.base};
+        border: 1px solid ${c.base};
         &:hover:not(:disabled) {
-          background: ${c.base}0A;
+          background: ${c.light};
           border-color: ${c.hover};
           color: ${c.hover};
         }
@@ -148,13 +156,13 @@ export const StyledButton = styled.button<{
       ghost: `
         background: ${$isPressed ? `${c.base}14` : 'transparent'};
         color: ${c.base};
-        &:hover:not(:disabled): {
+        &:hover:not(:disabled) {
           background: ${c.base}0A;
         }
-      `
-    }
+      `,
+    };
 
-    return typeStyles[$buttonType]
+    return variantStyles[$variant];
   }}
 
   /* Focus ring — visible on keyboard focus, not click */

--- a/packages/react/src/atoms/button/Button.tsx
+++ b/packages/react/src/atoms/button/Button.tsx
@@ -6,8 +6,8 @@ import { StyledButton } from './Button.styles';
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   function Button(props, forwardedRef) {
     const {
-      buttonType = 'contained',
-      variant = 'primary',
+      variant = 'solid',
+      intent = 'primary',
       size = 'md',
       isDisabled = false,
       fullWidth = false,
@@ -40,8 +40,8 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             forwardedRef.current = node;
           }
         }}
-        $buttonType={buttonType}
         $variant={variant}
+        $intent={intent}
         $size={size}
         $isPressed={isPressed}
         $isDisabled={isDisabled}

--- a/packages/react/src/atoms/button/Button.types.ts
+++ b/packages/react/src/atoms/button/Button.types.ts
@@ -1,13 +1,19 @@
-import type { UseButtonOptions } from "../../hooks";
-import type { ButtonType, ButtonVariant, ButtonSize, FullWidth, IsLoading } from '@molecule-ui/types'
+import type { UseButtonOptions } from '../../hooks';
+import type {
+  ButtonVariant,
+  ButtonIntent,
+  ButtonSize,
+  FullWidth,
+  IsLoading,
+} from '@molecule-ui/types';
 
 export type ButtonProps = Pick<UseButtonOptions, 'onPress' | 'onPressChange' | 'isDisabled'> & {
-    buttonType?: ButtonType;
-    variant?: ButtonVariant;
-    size?: ButtonSize;
-    fullWidth?: FullWidth;
-    children: React.ReactNode;
-    isLoading?: IsLoading;
-    'aria-label'?: string;
-    'data-testid'?: string;
-}
+  variant?: ButtonVariant;
+  intent?: ButtonIntent;
+  size?: ButtonSize;
+  fullWidth?: FullWidth;
+  children: React.ReactNode;
+  isLoading?: IsLoading;
+  'aria-label'?: string;
+  'data-testid'?: string;
+};

--- a/packages/types/src/components/atoms/badge.ts
+++ b/packages/types/src/components/atoms/badge.ts
@@ -1,11 +1,11 @@
-export type BadgeStatus = 'default' | 'primary' | 'success' | 'error' | 'info';
+export type BadgeIntent = 'neutral' | 'primary' | 'success' | 'danger' | 'brand';
 export type BadgeSize = 'sm' | 'md' | 'lg';
 
 //TODO: When adding the Vue component, content might need to be changed to using slots
 export type BadgeProps = {
-    status?: BadgeStatus;
-    size?: BadgeSize;
-    content: string;
-    className?: string;
-    testId?: string;
-}
+  intent?: BadgeIntent;
+  size?: BadgeSize;
+  content: string;
+  className?: string;
+  testId?: string;
+};

--- a/packages/types/src/components/atoms/button.ts
+++ b/packages/types/src/components/atoms/button.ts
@@ -1,5 +1,5 @@
-export type ButtonType = 'contained' | 'outlined' | 'ghost';
-export type ButtonVariant = 'primary' | 'brand' | 'success' | 'destructive';
+export type ButtonVariant = 'solid' | 'outline' | 'ghost';
+export type ButtonIntent = 'primary' | 'success' | 'danger' | 'brand';
 export type ButtonSize = 'sm' | 'md' | 'lg';
 export type FullWidth = boolean;
 export type IsLoading = boolean;


### PR DESCRIPTION
## Description
Renames props on Button and Badge to match the vocabulary used by Atlassian Design System, Radix UI, and shadcn/ui. This was done in tandem with creating the Figma component token collection, which already used the new naming.

## Work done
- Button — buttonType (contained/outlined/ghost) → variant (solid/outline/ghost); variant (primary/brand/success/destructive) → intent (primary/success/danger/brand)
- Badge — status (default/primary/success/error/info) → intent (neutral/primary/success/danger/brand); each intent now renders a distinct background and text color
- @molecule-ui/types — replaces ButtonType/ButtonVariant/BadgeStatus with ButtonVariant/ButtonIntent/BadgeIntent
- Bug fixes — corrected '1px soild' typo and stray CSS colon in Button ghost hover selector; fixed Badge always rendering theme.colors.primary text regardless of intent
- Stories — Button and Badge stories updated with proper Variant, Intent, and Size story exports and full argType controls