### PR TITLE
chore: initial alpha publish changeset

### DIFF
--- a/.changeset/pretty-rooms-mate.md
+++ b/.changeset/pretty-rooms-mate.md
@@ -1,0 +1,7 @@
+---
+'@molecule-ui/react': minor
+'@molecule-ui/types': minor
+'@molecule-ui/vue': minor
+---
+
+Initial release — Button, Badge, Chip atoms and ButtonGroup molecule

--- a/.claude/CHECKLIST.md
+++ b/.claude/CHECKLIST.md
@@ -90,7 +90,7 @@ Granular checklist for tooling, DX, and infrastructure work. Claude updates this
 - [x] `.changeset/config.json` — `access: public`, packages linked, `baseBranch: main`
 - [x] `changeset`, `version-packages`, and `release` scripts added to root `package.json`
 - [x] GitHub Actions release workflow — `changesets/action` creates version PR or publishes on merge to `main`
-- [ ] `NPM_TOKEN` secret added to GitHub repo settings
+- [x] `NPM_TOKEN` secret added to GitHub repo settings
 - [ ] `syncpack` installed to keep dependency versions consistent
 - [ ] First alpha publish of `@molecule-ui/react` and `@molecule-ui/vue`
 


### PR DESCRIPTION
## Summary

Adds a minor changeset across all three publishable packages for the initial `0.1.0` release.

- `@molecule-ui/react` — minor
- `@molecule-ui/vue` — minor
- `@molecule-ui/types` — minor

## What's included in this release

- Button, Badge, Chip atoms
- ButtonGroup molecule
- Token pipeline (Style Dictionary + Token Studio sync)

## After merging

The release Action will open a Version Packages PR that bumps all three packages to `0.1.0` and generates CHANGELOG.md entries. Merging that PR triggers the npm publish.

## Test plan

- [ ] Confirm changeset file looks correct
- [ ] Verify NPM_TOKEN secret is set in GitHub before merging the version PR