### PR TITLE
fix: remove explicit pnpm version and update Node to 22 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,11 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Fixes two issues in `.github/workflows/release.yml` that caused the release Action to fail:

- Removed `version: 10` from the `pnpm/action-setup@v4` step — the `packageManager` field in `package.json` already pins `pnpm@10.14.0`, and specifying both causes an `ERR_PNPM_BAD_PM_VERSION` error
- Updated `node-version` from `20` to `22` to match `ci.yml` and `chromatic.yml`