### PR TITLE
fix: add write permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
## Summary

The release Action was failing with a 403 when `github-actions[bot]` tried to push the `changeset-release/main` branch. GitHub Actions tokens default to read-only unless permissions are explicitly granted.

Adds top-level permissions to the workflow:
- `contents: write` — allows pushing the version branch
- `pull-requests: write` — allows opening the version PR