### PR TITLE
fix: skip Husky in CI to prevent hooks firing during release

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "pnpm build && changeset publish",
-    "prepare": "husky || true"
+    "prepare": "[ -z \"$CI\" ] && husky || true"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",


### PR DESCRIPTION
## Summary

The release Action was failing because Changesets runs `git push` internally, which triggered the Husky pre-push hook. The hook ran `pnpm typecheck`, which failed because `@molecule-ui/types` had not been built yet (no `dist/` in CI).

Changes the `prepare` script from `husky || true` to `[ -z "$CI" ] && husky || true` — Husky skips installation when the `CI` environment variable is set (which GitHub Actions sets automatically), so no hooks fire during CI runs.