### PR TITLE
chore: rename @molecule-ui packages to @atomly-ai + alpha changeset

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
-  "linked": [["@molecule-ui/react", "@molecule-ui/vue", "@molecule-ui/types"]],
+  "linked": [["@atomly-ai/react", "@atomly-ai/vue", "@atomly-ai/types"]],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",

--- a/.changeset/initial-atomly-ai-alpha.md
+++ b/.changeset/initial-atomly-ai-alpha.md
@@ -1,0 +1,7 @@
+---
+'@atomly-ai/react': minor
+'@atomly-ai/vue': minor
+'@atomly-ai/types': minor
+---
+
+Initial alpha release of the Atomly UI packages (`@atomly-ai/react`, `@atomly-ai/vue`, `@atomly-ai/types`), previously scoped under `@molecule-ui`. Includes the Button, Badge, and Chip atoms, the ButtonGroup molecule, the icon set, and the shared prop types.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,11 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "@atomly-ai/react": "0.1.0",
+    "@atomly-ai/types": "0.1.0",
+    "@atomly-ai/vue": "0.1.0",
+    "@atomly-ai/website": "0.0.2"
+  },
+  "changesets": []
+}

--- a/.claude/CHECKLIST.md
+++ b/.claude/CHECKLIST.md
@@ -80,7 +80,22 @@ Granular checklist for tooling, DX, and infrastructure work. Claude updates this
 - [x] `pre-push` hook: `build:icons` diff-check (wired in during icon pipeline)
 - [x] GitHub Actions workflow: lint → build → test on PRs
 - [x] GitHub Actions workflow: Chromatic on PRs
-- [ ] GitHub Actions workflow: publish to npm on release
+- [ ] GitHub Actions workflow: publish to npm on release — blocked on rename to `@atomly-ai` first
+
+---
+
+## Rename: molecule-ui → @atomly-ai
+
+> Name history: `molecule-ai` and `ai-atoms` scopes were already taken on npm. Final name is `@atomly-ai`.
+
+- [x] Create npm org `atomly-ai` (Free plan, public packages)
+- [x] Rename all package names in `package.json` files (`@molecule-ui/*` → `@atomly-ai/*`) + `workspace:*` deps
+- [x] Update all import statements across the codebase (~11 React source files + website)
+- [x] Update all references in `CLAUDE.md`, `README.md`, `ROADMAP.md`, `.claude/` docs, config files, and workflows
+- [x] Update `.changeset/config.json` linked packages array
+- [x] Regenerate `pnpm-lock.yaml` (`pnpm install`) and verify build (`pnpm build:types && pnpm build` — ✅ passes)
+- [x] Rename GitHub repo to `atomly-ai`
+- [x] Update remote URL locally after GitHub rename
 
 ---
 
@@ -92,17 +107,17 @@ Granular checklist for tooling, DX, and infrastructure work. Claude updates this
 - [x] GitHub Actions release workflow — `changesets/action` creates version PR or publishes on merge to `main`
 - [x] `NPM_TOKEN` secret added to GitHub repo settings
 - [ ] `syncpack` installed to keep dependency versions consistent
-- [ ] First alpha publish of `@molecule-ui/react` and `@molecule-ui/vue`
+- [ ] First alpha publish of `@atomly-ai/react` and `@atomly-ai/vue`
 
 ---
 
 ## Bundle Health
 
-- [ ] `size-limit` installed with per-package size budgets (`@molecule-ui/react`, `@molecule-ui/vue`)
+- [ ] `size-limit` installed with per-package size budgets (`@atomly-ai/react`, `@atomly-ai/vue`)
 - [ ] Size limit check added to GitHub Actions CI (fails PR if budget exceeded)
 - [ ] `rollup-plugin-visualizer` added to Vite config for bundle composition inspection
 - [ ] Baseline bundle sizes documented after first stable release
-- [ ] Tree-shaking validated — confirm per-category imports (`@molecule-ui/react/atoms`) are smaller than full import
+- [ ] Tree-shaking validated — confirm per-category imports (`@atomly-ai/react/atoms`) are smaller than full import
 
 ---
 
@@ -115,7 +130,7 @@ Components are named `AlertIcon`, `CloseIcon`, etc. (noun + Icon suffix). SVG so
 - [x] Add `build:icons` script to `packages/react` — Node.js script using `@svgr/core` to generate `AlertIcon.tsx` etc. into `src/atoms/icons/`, with `currentColor`, title prop, TypeScript output, and auto-generated `index.ts`
 - [x] Write `packages/vue/scripts/build-icons.mjs` — Node.js script that reads `icons/*.svg`, optimizes with `svgo`, and wraps each in a `<script lang="ts" setup>` Vue SFC with `inheritAttrs: false`
 - [x] Add `build:icons` script to `packages/vue`
-- [x] Add root `build:icons` script: `pnpm -F @molecule-ui/react build:icons && pnpm -F @molecule-ui/vue build:icons`
+- [x] Add root `build:icons` script: `pnpm -F @atomly-ai/react build:icons && pnpm -F @atomly-ai/vue build:icons`
 - [x] Generated icon components auto-exported from `packages/react/src/atoms/index.ts` and `packages/vue/src/atoms/index.ts`
 - [x] Add icon types to `packages/types` (`IconName` union, `IconSize`)
 - [x] Add Storybook stories for the icon set (AllIcons grid, Sizes, Colors — in both React and Vue)

--- a/.claude/commands/audit-component.md
+++ b/.claude/commands/audit-component.md
@@ -10,13 +10,15 @@ If the framework is not specified, audit both packages if the component exists i
 **React checklist** — `packages/react/src/atoms/<lowercase>/` or `molecules/<lowercase>/`
 
 Types (`packages/types/src/components/`):
+
 - [ ] Type file exists for this component
 - [ ] Includes `children: React.ReactNode`
 - [ ] Includes `'data-testid'?: string`
 - [ ] Re-exported from the category types index (`atoms/index.ts` or `molecules/index.ts`)
 
 Component files:
-- [ ] `<Name>.types.ts` imports from `@molecule-ui/types`
+
+- [ ] `<Name>.types.ts` imports from `@atomly-ai/types`
 - [ ] `<Name>.styles.ts` uses `$`-prefixed transient props for all styled-component-only props
 - [ ] `<Name>.styles.ts` has at least one theme token read with a fallback value
 - [ ] `<Name>.tsx` uses `React.forwardRef`
@@ -35,7 +37,7 @@ Component files:
 
 - [ ] Type file exists in `packages/types/src/components/` (may be shared with React)
 - [ ] `<Name>.vue` uses `<script lang="ts" setup>`
-- [ ] `<Name>.vue` uses `defineProps` + `withDefaults` and imports types from `@molecule-ui/types`
+- [ ] `<Name>.vue` uses `defineProps` + `withDefaults` and imports types from `@atomly-ai/types`
 - [ ] `<Name>.vue` includes `<slot />` for children
 - [ ] `<Name>.vue` spreads `data-testid` onto the root element
 - [ ] `<name>.css` exists with at least one CSS custom property placeholder

--- a/.claude/commands/audit-react-library.md
+++ b/.claude/commands/audit-react-library.md
@@ -14,7 +14,7 @@ Follow these steps:
    - [ ] Re-exported from the category types index
 
    Component files:
-   - [ ] `<Name>.types.ts` imports from `@molecule-ui/types`
+   - [ ] `<Name>.types.ts` imports from `@atomly-ai/types`
    - [ ] `<Name>.styles.ts` uses `$`-prefixed transient props and has at least one theme token with a fallback
    - [ ] `<Name>.tsx` uses `React.forwardRef`, sets `displayName`, has both named and default export
    - [ ] `<Name>.tsx` does not import directly from `@react-aria/*`

--- a/.claude/commands/audit-vue-library.md
+++ b/.claude/commands/audit-vue-library.md
@@ -7,10 +7,9 @@ Follow these steps:
 1. **Discover all components** by reading `packages/vue/src/atoms/index.ts` and `packages/vue/src/molecules/index.ts` to get the full list.
 
 2. **For each component**, check the following in `packages/vue/src/atoms/<lowercase>/` or `molecules/<lowercase>/`:
-
    - [ ] Type file exists in `packages/types/src/components/` (may be shared with React)
    - [ ] `<Name>.vue` uses `<script lang="ts" setup>`
-   - [ ] `<Name>.vue` uses `defineProps` + `withDefaults` and imports types from `@molecule-ui/types`
+   - [ ] `<Name>.vue` uses `defineProps` + `withDefaults` and imports types from `@atomly-ai/types`
    - [ ] `<Name>.vue` includes `<slot />` for children
    - [ ] `<Name>.vue` spreads `data-testid` onto the root element
    - [ ] `<name>.css` exists with at least one CSS custom property placeholder

--- a/.claude/commands/create-react-atom.md
+++ b/.claude/commands/create-react-atom.md
@@ -13,10 +13,10 @@ Follow these steps in order:
    Then add `export * from './<lowercase-name>'` to `packages/types/src/components/atoms/index.ts`.
 
 2. **Component folder** — Create `packages/react/src/atoms/<lowercase-name>/` with these five files:
-
-   - `<Name>.types.ts` — import the base types from `@molecule-ui/types` and extend them into the public `<Name>Props` interface. Include `React.RefAttributes<HTMLElement>` if using forwardRef.
+   - `<Name>.types.ts` — import the base types from `@atomly-ai/types` and extend them into the public `<Name>Props` interface. Include `React.RefAttributes<HTMLElement>` if using forwardRef.
 
    - `<Name>.styles.ts` — a single `Styled<Name>` Emotion `styled` component. Use `$`-prefixed transient props. Always include at least one token-backed style with a fallback, e.g.:
+
      ```ts
      font-family: ${({ theme }) => theme.typography?.fontFamily ?? 'inherit'};
      ```

--- a/.claude/commands/create-react-molecule.md
+++ b/.claude/commands/create-react-molecule.md
@@ -13,10 +13,10 @@ Molecules are composed components built from atoms. Follow these steps in order:
    Then add `export * from './<lowercase-name>'` to `packages/types/src/components/molecules/index.ts`.
 
 2. **Component folder** — Create `packages/react/src/molecules/<lowercase-name>/` with these five files:
-
-   - `<Name>.types.ts` — import the base types from `@molecule-ui/types` and extend them into the public `<Name>Props` interface. Include `React.RefAttributes<HTMLElement>` if using forwardRef.
+   - `<Name>.types.ts` — import the base types from `@atomly-ai/types` and extend them into the public `<Name>Props` interface. Include `React.RefAttributes<HTMLElement>` if using forwardRef.
 
    - `<Name>.styles.ts` — Emotion `styled` wrapper component(s). Use `$`-prefixed transient props. Always include at least one token-backed style with a fallback, e.g.:
+
      ```ts
      font-family: ${({ theme }) => theme.typography?.fontFamily ?? 'inherit'};
      ```

--- a/.claude/commands/create-vue-atom.md
+++ b/.claude/commands/create-vue-atom.md
@@ -12,12 +12,12 @@ Follow these steps in order:
    Then add `export * from './<lowercase-name>'` to `packages/types/src/components/atoms/index.ts`. Skip this step if the React atom was already created and types exist.
 
 2. **Component folder** — Create `packages/vue/src/atoms/<lowercase-name>/` with these four files:
-
-   - `<Name>.vue` — Single File Component using `<script lang="ts" setup>`. Define props with `defineProps` + `withDefaults`, importing prop types from `@molecule-ui/types`. Always include a default slot (`<slot />`) so the component accepts children. Spread `data-testid` onto the root element. Use a semantically appropriate HTML element. Apply scoped CSS classes for styling.
+   - `<Name>.vue` — Single File Component using `<script lang="ts" setup>`. Define props with `defineProps` + `withDefaults`, importing prop types from `@atomly-ai/types`. Always include a default slot (`<slot />`) so the component accepts children. Spread `data-testid` onto the root element. Use a semantically appropriate HTML element. Apply scoped CSS classes for styling.
 
    - `<name>.css` — scoped styles for the component. Always include at least one placeholder rule using a CSS custom property where a design token will eventually be wired in, e.g.:
+
      ```css
-     .molecule-<name> {
+     .molecule-<name > {
        font-family: var(--molecule-font-family, inherit);
      }
      ```

--- a/.claude/commands/create-vue-molecule.md
+++ b/.claude/commands/create-vue-molecule.md
@@ -12,12 +12,12 @@ Molecules are composed components built from atoms. Follow these steps in order:
    Then add `export * from './<lowercase-name>'` to `packages/types/src/components/molecules/index.ts`. Skip this step if the React molecule was already created and types exist.
 
 2. **Component folder** — Create `packages/vue/src/molecules/<lowercase-name>/` with these four files:
-
-   - `<Name>.vue` — Single File Component using `<script lang="ts" setup>`. Import and compose atom components from `../../atoms`. Define props with `defineProps` + `withDefaults`, importing prop types from `@molecule-ui/types`. Always include a default slot (`<slot />`) so the component accepts children. Spread `data-testid` onto the root element. Apply scoped CSS classes for styling.
+   - `<Name>.vue` — Single File Component using `<script lang="ts" setup>`. Import and compose atom components from `../../atoms`. Define props with `defineProps` + `withDefaults`, importing prop types from `@atomly-ai/types`. Always include a default slot (`<slot />`) so the component accepts children. Spread `data-testid` onto the root element. Apply scoped CSS classes for styling.
 
    - `<name>.css` — scoped styles for the component. Always include at least one placeholder rule using a CSS custom property where a design token will eventually be wired in, e.g.:
+
      ```css
-     .molecule-<name> {
+     .molecule-<name > {
        font-family: var(--molecule-font-family, inherit);
      }
      ```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,8 +8,8 @@
       "Bash(pnpm dev:website)",
       "Bash(pnpm lint)",
       "Bash(pnpm format)",
-      "Bash(pnpm -F @molecule-ui/react vitest*)",
-      "Bash(pnpm -F @molecule-ui/vue vitest*)"
+      "Bash(pnpm -F @atomly-ai/react vitest*)",
+      "Bash(pnpm -F @atomly-ai/vue vitest*)"
     ]
   },
   "hooks": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,11 @@ jobs:
 
       - name: Install Playwright browsers
         run: |
-          pnpm -F @molecule-ui/react exec playwright install chromium --with-deps
-          pnpm -F @molecule-ui/vue exec playwright install chromium --with-deps
+          pnpm -F @atomly-ai/react exec playwright install chromium --with-deps
+          pnpm -F @atomly-ai/vue exec playwright install chromium --with-deps
 
       - name: Test (React)
-        run: pnpm -F @molecule-ui/react vitest run
+        run: pnpm -F @atomly-ai/react vitest run
 
       - name: Test (Vue)
-        run: pnpm -F @molecule-ui/vue vitest run
+        run: pnpm -F @atomly-ai/vue vitest run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,18 +31,18 @@ pnpm lint
 pnpm format
 ```
 
-> Always run `pnpm build:types` before building `@molecule-ui/react` or `@molecule-ui/vue` if you've changed anything in `packages/types`.
+> Always run `pnpm build:types` before building `@atomly-ai/react` or `@atomly-ai/vue` if you've changed anything in `packages/types`.
 
 ## Architecture
 
 ### Package Structure
 
-| Package            | Name                   | Role                                                                         |
-| ------------------ | ---------------------- | ---------------------------------------------------------------------------- |
-| `packages/types`   | `@molecule-ui/types`   | Shared TypeScript prop types — single source of truth for all component APIs |
-| `packages/react`   | `@molecule-ui/react`   | React component library                                                      |
-| `packages/vue`     | `@molecule-ui/vue`     | Vue component library                                                        |
-| `packages/website` | `@molecule-ui/website` | Next.js documentation site                                                   |
+| Package            | Name                 | Role                                                                         |
+| ------------------ | -------------------- | ---------------------------------------------------------------------------- |
+| `packages/types`   | `@atomly-ai/types`   | Shared TypeScript prop types — single source of truth for all component APIs |
+| `packages/react`   | `@atomly-ai/react`   | React component library                                                      |
+| `packages/vue`     | `@atomly-ai/vue`     | Vue component library                                                        |
+| `packages/website` | `@atomly-ai/website` | Next.js documentation site                                                   |
 
 ### Component Organization (Atomic Design)
 
@@ -73,7 +73,7 @@ The Storybook `preview.tsx` wraps all stories in `MoleculeProvider` automaticall
 
 ### Type Flow
 
-Prop types are defined in `@molecule-ui/types` and imported into both framework packages. Adding a new prop value means changing it once in `packages/types/src/components/` and it propagates to React and Vue.
+Prop types are defined in `@atomly-ai/types` and imported into both framework packages. Adding a new prop value means changing it once in `packages/types/src/components/` and it propagates to React and Vue.
 
 ### Build & Exports
 
@@ -86,7 +86,7 @@ Vite builds the React package as an ES module library with three entry points (`
 2. **Create the component folder** at `packages/react/src/atoms/<name>/` with these five files:
    - `<Name>.tsx` — component using `React.forwardRef`; set `<Name>.displayName`
    - `<Name>.styles.ts` — Emotion `styled` component; use `$`-prefixed transient props to avoid DOM leakage
-   - `<Name>.types.ts` — imports from `@molecule-ui/types` and builds the public prop interface
+   - `<Name>.types.ts` — imports from `@atomly-ai/types` and builds the public prop interface
    - `<Name>.stories.tsx` — Storybook stories with `title: 'Atoms/<Name>'` and `tags: ['autodocs']`
    - `index.ts` — barrel: `export { default as <Name> } from './<Name>'` + `export type { <Name>Props }`
 
@@ -101,7 +101,7 @@ The same pattern applies for molecules under `src/molecules/`, and for adding an
 - **Transient props**: prefix styled-component-only props with `$` (e.g., `$size`, `$variant`, `$isDisabled`) to prevent them from forwarding to the DOM element.
 - **React Aria**: accessibility behavior (keyboard events, press states, ARIA attributes) is handled via hooks in `src/hooks/` that wrap `@react-aria/*`. Add new hooks there rather than importing React Aria directly in components.
 - **`useButton` hook**: wraps `@react-aria/button` and returns `{ buttonProps, isPressed, buttonRef }`. The component is responsible for merging `buttonRef` with any `forwardedRef` from consumers.
-- **Types package must be built first**: the React and Vue packages import from `@molecule-ui/types` at build time via the `workspace:*` protocol.
+- **Types package must be built first**: the React and Vue packages import from `@atomly-ai/types` at build time via the `workspace:*` protocol.
 
 ## Design System References
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ A monorepo design system publishing React and Vue component libraries built on a
 
 ## Packages
 
-| Package                                    | Description                                    |
-| ------------------------------------------ | ---------------------------------------------- |
-| [`@molecule-ui/react`](packages/react)     | React component library (Emotion + React Aria) |
-| [`@molecule-ui/vue`](packages/vue)         | Vue 3 component library                        |
-| [`@molecule-ui/types`](packages/types)     | Shared TypeScript prop types                   |
-| [`@molecule-ui/website`](packages/website) | Documentation site (Next.js)                   |
+| Package                                  | Description                                    |
+| ---------------------------------------- | ---------------------------------------------- |
+| [`@atomly-ai/react`](packages/react)     | React component library (Emotion + React Aria) |
+| [`@atomly-ai/vue`](packages/vue)         | Vue 3 component library                        |
+| [`@atomly-ai/types`](packages/types)     | Shared TypeScript prop types                   |
+| [`@atomly-ai/website`](packages/website) | Documentation site (Next.js)                   |
 
 ## Requirements
 
@@ -65,9 +65,9 @@ pnpm format
 
 ```
 packages/
-  react/       # @molecule-ui/react — atoms, molecules, hooks, theme
-  vue/         # @molecule-ui/vue — atoms, molecules, composables
-  types/       # @molecule-ui/types — shared prop type definitions
+  react/       # @atomly-ai/react — atoms, molecules, hooks, theme
+  vue/         # @atomly-ai/vue — atoms, molecules, composables
+  types/       # @atomly-ai/types — shared prop type definitions
   website/     # Documentation site
 figma/         # Figma Code Connect config
 tokens/        # Raw design token exports from Figma
@@ -75,7 +75,7 @@ tokens/        # Raw design token exports from Figma
 
 ## Releasing
 
-This repo uses [Changesets](https://github.com/changesets/changesets) to manage versioning and publishing. All three publishable packages (`@molecule-ui/react`, `@molecule-ui/vue`, `@molecule-ui/types`) are linked — they always release at the same version.
+This repo uses [Changesets](https://github.com/changesets/changesets) to manage versioning and publishing. All three publishable packages (`@atomly-ai/react`, `@atomly-ai/vue`, `@atomly-ai/types`) are linked — they always release at the same version.
 
 ### Workflow for contributors
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,8 +9,8 @@ High-level phases and goals for the project. Updated as priorities shift.
 Get the core infrastructure solid before building out the component library.
 
 - [x] Monorepo setup (pnpm workspaces, TypeScript, shared types package)
-- [x] React component library (`@molecule-ui/react`) with Emotion + React Aria
-- [x] Vue component library (`@molecule-ui/vue`)
+- [x] React component library (`@atomly-ai/react`) with Emotion + React Aria
+- [x] Vue component library (`@atomly-ai/vue`)
 - [x] Storybook for React and Vue
 - [x] Claude Code tooling (slash commands, CLAUDE.md files, specs, hooks)
 - [x] Figma project created (Design Tokens + Component Library files)
@@ -40,6 +40,7 @@ Establish the design token pipeline so components are tied to Figma.
 Build out the foundational atom and molecule set.
 
 **Atoms**
+
 - [x] Button
 - [x] Badge
 - [ ] Icon
@@ -55,6 +56,7 @@ Build out the foundational atom and molecule set.
 - [ ] Divider
 
 **Molecules**
+
 - [x] ButtonGroup
 - [ ] FormField (label + input + error)
 - [ ] Modal / Dialog
@@ -99,4 +101,4 @@ Build out the foundational atom and molecule set.
 - Motion / animation token category
 - Breakpoint tokens for responsive components
 - Figma library published for internal design use
-- React Native package (`@molecule-ui/native`)
+- React Native package (`@atomly-ai/native`)

--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
-  "name": "molecule-ui",
+  "name": "atomly-ai",
   "version": "0.0.1",
   "private": true,
   "type": "module",
   "description": "React and Vue component library for the molecule-ui design system.",
   "scripts": {
-    "build": "pnpm -F @molecule-ui/types build && pnpm -F @molecule-ui/react build && pnpm -F @molecule-ui/vue build",
-    "build:types": "pnpm -F @molecule-ui/types build",
-    "dev:website": "pnpm -F @molecule-ui/website dev",
-    "dev:storybook-react": "pnpm -F @molecule-ui/react storybook",
-    "dev:storybook-vue": "pnpm -F @molecule-ui/vue storybook",
+    "build": "pnpm -F @atomly-ai/types build && pnpm -F @atomly-ai/react build && pnpm -F @atomly-ai/vue build",
+    "build:types": "pnpm -F @atomly-ai/types build",
+    "dev:website": "pnpm -F @atomly-ai/website dev",
+    "dev:storybook-react": "pnpm -F @atomly-ai/react storybook",
+    "dev:storybook-vue": "pnpm -F @atomly-ai/vue storybook",
     "sync:tokens": "node scripts/sync-figma-tokens.mjs && node style-dictionary.config.mjs",
     "build:tokens": "node style-dictionary.config.mjs",
-    "build:icons": "pnpm -F @molecule-ui/react build:icons && pnpm -F @molecule-ui/vue build:icons",
+    "build:icons": "pnpm -F @atomly-ai/react build:icons && pnpm -F @atomly-ai/vue build:icons",
     "lint": "eslint .",
     "format": "prettier --write .",
-    "typecheck": "pnpm -F @molecule-ui/types exec tsc --noEmit && pnpm -F @molecule-ui/react exec tsc --noEmit && pnpm -F @molecule-ui/vue exec tsc --noEmit",
+    "typecheck": "pnpm -F @atomly-ai/types exec tsc --noEmit && pnpm -F @atomly-ai/react exec tsc --noEmit && pnpm -F @atomly-ai/vue exec tsc --noEmit",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "pnpm build && changeset publish",
@@ -51,7 +51,7 @@
   "packageManager": "pnpm@10.14.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/recondesigns/molecule-ui.git"
+    "url": "git+https://github.com/recondesigns/atomly-ai.git"
   },
   "license": "MIT",
   "lint-staged": {

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @molecule-ui/react
+# @atomly-ai/react
 
 ## 0.1.0
 
@@ -9,4 +9,4 @@
 ### Patch Changes
 
 - Updated dependencies [5210a3a]
-  - @molecule-ui/types@0.1.0
+  - @atomly-ai/types@0.1.0

--- a/packages/react/CLAUDE.md
+++ b/packages/react/CLAUDE.md
@@ -1,4 +1,4 @@
-# packages/react — @molecule-ui/react
+# packages/react — @atomly-ai/react
 
 React component library package. See the root `CLAUDE.md` for monorepo-wide conventions. This file covers React-specific implementation details.
 
@@ -64,4 +64,4 @@ Vite builds to `dist/` as an ES module with `preserveModules` (one output file p
 
 All peer dependencies are externalized: `react`, `react-dom`, `react/jsx-runtime`, all `@emotion/*`, all `@react-aria/*`, all `@react-stately/*`.
 
-Run `pnpm build:types` (from repo root) first if `packages/types` changed, then `pnpm -F @molecule-ui/react build`.
+Run `pnpm build:types` (from repo root) first if `packages/types` changed, then `pnpm -F @atomly-ai/react build`.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,3 +1,3 @@
-# @molecule-ui/react
+# @atomly-ai/react
 
 React UI components.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@molecule-ui/react",
+  "name": "@atomly-ai/react",
   "version": "0.1.0",
   "type": "module",
   "description": "Molecule UI React components",
@@ -36,7 +36,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
-    "@molecule-ui/types": "workspace:*",
+    "@atomly-ai/types": "workspace:*",
     "@react-aria/button": "^3.14.4",
     "@react-aria/focus": "^3.21.4",
     "@react-aria/interactions": "^3.27.0",
@@ -86,14 +86,14 @@
     "name": "Stedman",
     "url": "https://github.com/recondesigns"
   },
-  "homepage": "https://github.com/recondesigns/molecule-ui#readme",
+  "homepage": "https://github.com/recondesigns/atomly-ai#readme",
   "bugs": {
-    "url": "https://github.com/recondesigns/molecule-ui/issues"
+    "url": "https://github.com/recondesigns/atomly-ai/issues"
   },
   "license": "MIT",
   "packageManager": "pnpm@10.14.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/recondesigns/molecule-ui.git"
+    "url": "git+https://github.com/recondesigns/atomly-ai.git"
   }
 }

--- a/packages/react/src/atoms/badge/Badge.styles.ts
+++ b/packages/react/src/atoms/badge/Badge.styles.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import type { BadgeIntent, BadgeSize } from '@molecule-ui/types';
+import type { BadgeIntent, BadgeSize } from '@atomly-ai/types';
 
 const sizeStyles: Record<
   BadgeSize,

--- a/packages/react/src/atoms/badge/Badge.types.ts
+++ b/packages/react/src/atoms/badge/Badge.types.ts
@@ -1,4 +1,4 @@
-import type { BadgeProps as BadgePropsType } from '@molecule-ui/types';
+import type { BadgeProps as BadgePropsType } from '@atomly-ai/types';
 
 export type BadgeProps = {
   intent?: BadgePropsType['intent'];

--- a/packages/react/src/atoms/button/Button.styles.ts
+++ b/packages/react/src/atoms/button/Button.styles.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import type { ButtonVariant, ButtonIntent, ButtonSize } from '@molecule-ui/types';
+import type { ButtonVariant, ButtonIntent, ButtonSize } from '@atomly-ai/types';
 
 const sizeStyles: Record<
   ButtonSize,

--- a/packages/react/src/atoms/button/Button.types.ts
+++ b/packages/react/src/atoms/button/Button.types.ts
@@ -5,7 +5,7 @@ import type {
   ButtonSize,
   FullWidth,
   IsLoading,
-} from '@molecule-ui/types';
+} from '@atomly-ai/types';
 
 export type ButtonProps = Pick<UseButtonOptions, 'onPress' | 'onPressChange' | 'isDisabled'> & {
   variant?: ButtonVariant;

--- a/packages/react/src/atoms/chip/Chip.styles.ts
+++ b/packages/react/src/atoms/chip/Chip.styles.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import type { ChipVariant, ChipIntent, ChipSize } from '@molecule-ui/types';
+import type { ChipVariant, ChipIntent, ChipSize } from '@atomly-ai/types';
 
 type ChipColors = { bg: string; border: string; text: string };
 

--- a/packages/react/src/atoms/chip/Chip.types.ts
+++ b/packages/react/src/atoms/chip/Chip.types.ts
@@ -1,4 +1,4 @@
-import type { ChipVariant, ChipIntent, ChipSize } from '@molecule-ui/types';
+import type { ChipVariant, ChipIntent, ChipSize } from '@atomly-ai/types';
 
 export type ChipProps = {
   variant?: ChipVariant;

--- a/packages/react/src/molecules/button-group/ButtonGroup.stories.tsx
+++ b/packages/react/src/molecules/button-group/ButtonGroup.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import ButtonGroup from './ButtonGroup';
-// import type { ButtonGroupProps } from '@molecule-ui/types';
+// import type { ButtonGroupProps } from '@atomly-ai/types';
 import type { ButtonGroupProps } from './ButtonGroup';
 
 const meta = {

--- a/packages/react/src/molecules/button-group/ButtonGroup.tsx
+++ b/packages/react/src/molecules/button-group/ButtonGroup.tsx
@@ -1,6 +1,6 @@
 // import React from 'react';
 // import { Button } from '../../atoms';
-// import { ButtonGroupProps } from '@molecule-ui/types';
+// import { ButtonGroupProps } from '@atomly-ai/types';
 
 type Action = {
   label: string;

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @molecule-ui/types
+# @atomly-ai/types
 
 ## 0.1.0
 

--- a/packages/types/CLAUDE.md
+++ b/packages/types/CLAUDE.md
@@ -1,10 +1,11 @@
-# packages/types — @molecule-ui/types
+# packages/types — @atomly-ai/types
 
-Shared TypeScript types package. This is the single source of truth for all component prop types — both `@molecule-ui/react` and `@molecule-ui/vue` import from here.
+Shared TypeScript types package. This is the single source of truth for all component prop types — both `@atomly-ai/react` and `@atomly-ai/vue` import from here.
 
 ## Purpose
 
 Centralizing types here means:
+
 - A prop value (e.g. a new `ButtonVariant`) is added once and propagates to both framework packages automatically
 - The type surface is auditable in one place
 - Consumers who use both packages get consistent types
@@ -30,11 +31,11 @@ src/components/
 1. Create `src/components/atoms/<name>.ts` (or `molecules/`)
 2. Export all union types and standalone types needed by the component
 3. Add `export * from './<name>'` to the category `index.ts`
-4. Run `pnpm build:types` from the repo root before building `@molecule-ui/react` or `@molecule-ui/vue`
+4. Run `pnpm build:types` from the repo root before building `@atomly-ai/react` or `@atomly-ai/vue`
 
 ## Build order
 
-This package **must be built first**. Both `@molecule-ui/react` and `@molecule-ui/vue` reference it via `workspace:*` and resolve the built `dist/` at build time. If you skip this step, downstream builds will fail with missing type errors.
+This package **must be built first**. Both `@atomly-ai/react` and `@atomly-ai/vue` reference it via `workspace:*` and resolve the built `dist/` at build time. If you skip this step, downstream builds will fail with missing type errors.
 
 ```bash
 pnpm build:types          # build this package

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,3 +1,3 @@
-# @molecule-ui/types
+# @atomly-ai/types
 
 Shared types.

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@molecule-ui/types",
+  "name": "@atomly-ai/types",
   "version": "0.1.0",
   "type": "module",
   "description": "Shared types for Molecule UI",
@@ -32,9 +32,9 @@
     "name": "Stedman",
     "url": "https://github.com/recondesigns"
   },
-  "homepage": "https://github.com/recondesigns/molecule-ui#readme",
+  "homepage": "https://github.com/recondesigns/atomly-ai#readme",
   "bugs": {
-    "url": "https://github.com/recondesigns/molecule-ui/issues"
+    "url": "https://github.com/recondesigns/atomly-ai/issues"
   },
   "license": "MIT"
 }

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @molecule-ui/vue
+# @atomly-ai/vue
 
 ## 0.1.0
 
@@ -9,4 +9,4 @@
 ### Patch Changes
 
 - Updated dependencies [5210a3a]
-  - @molecule-ui/types@0.1.0
+  - @atomly-ai/types@0.1.0

--- a/packages/vue/CLAUDE.md
+++ b/packages/vue/CLAUDE.md
@@ -1,4 +1,4 @@
-# packages/vue — @molecule-ui/vue
+# packages/vue — @atomly-ai/vue
 
 Vue 3 component library package. See the root `CLAUDE.md` for monorepo-wide conventions. This file covers Vue-specific implementation details.
 
@@ -21,7 +21,7 @@ Every component is a Single File Component (`.vue`) using `<script lang="ts" set
 </template>
 
 <script lang="ts" setup>
-import type { NameProp } from '@molecule-ui/types';
+import type { NameProp } from '@atomly-ai/types';
 
 withDefaults(
   defineProps<{
@@ -39,7 +39,7 @@ Rules:
 
 - Always include `<slot />` — Vue's equivalent of `children`
 - Always spread `data-testid` onto the root element (use `:data-testid="dataTestid"` after destructuring or bind directly)
-- Import prop type unions from `@molecule-ui/types` — do not redeclare them locally
+- Import prop type unions from `@atomly-ai/types` — do not redeclare them locally
 - Use `withDefaults` to document and enforce default prop values
 
 ## CSS conventions
@@ -97,4 +97,4 @@ A11y checks are configured as `test: 'error'` — violations fail the Vitest sto
 
 Same structure as the React package: ES module, `preserveModules`, three entry points (`index`, `atoms/index`, `molecules/index`). `vue` is externalized as a peer dependency.
 
-Run `pnpm build:types` first if `packages/types` changed, then `pnpm -F @molecule-ui/vue build`.
+Run `pnpm build:types` first if `packages/types` changed, then `pnpm -F @atomly-ai/vue build`.

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,3 +1,3 @@
-# @molecule-ui/vue
+# @atomly-ai/vue
 
 Vue UI components.

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@molecule-ui/vue",
+  "name": "@atomly-ai/vue",
   "version": "0.1.0",
   "type": "module",
   "description": "Molecule UI Vue components",
@@ -33,7 +33,7 @@
     "vue": "^3.4.0"
   },
   "dependencies": {
-    "@molecule-ui/types": "workspace:*"
+    "@atomly-ai/types": "workspace:*"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^5.0.1",
@@ -72,14 +72,14 @@
     "name": "Stedman",
     "url": "https://github.com/recondesigns"
   },
-  "homepage": "https://github.com/recondesigns/molecule-ui#readme",
+  "homepage": "https://github.com/recondesigns/atomly-ai#readme",
   "bugs": {
-    "url": "https://github.com/recondesigns/molecule-ui/issues"
+    "url": "https://github.com/recondesigns/atomly-ai/issues"
   },
   "license": "MIT",
   "packageManager": "pnpm@10.14.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/recondesigns/molecule-ui.git"
+    "url": "git+https://github.com/recondesigns/atomly-ai.git"
   }
 }

--- a/packages/website/CHANGELOG.md
+++ b/packages/website/CHANGELOG.md
@@ -1,8 +1,8 @@
-# @molecule-ui/website
+# @atomly-ai/website
 
 ## 0.0.2
 
 ### Patch Changes
 
 - Updated dependencies [5210a3a]
-  - @molecule-ui/react@0.1.0
+  - @atomly-ai/react@0.1.0

--- a/packages/website/CLAUDE.md
+++ b/packages/website/CLAUDE.md
@@ -1,11 +1,11 @@
-# packages/website — @molecule-ui/website
+# packages/website — @atomly-ai/website
 
 Next.js documentation and playground site for Molecule UI. Currently a dev playground; will become the public-facing component docs site.
 
 ## Stack
 
 - **Next.js** (App Router, `src/app/`)
-- Imports components from `@molecule-ui/react` via the workspace
+- Imports components from `@atomly-ai/react` via the workspace
 
 ## Running
 
@@ -16,5 +16,5 @@ pnpm dev:website    # from repo root — starts Next.js dev server
 ## Notes
 
 - This package has its own `pnpm-lock.yaml` and `pnpm-workspace.yaml` — it is a nested workspace. Don't confuse it with the root workspace.
-- It consumes `@molecule-ui/react` as a dependency. If you change the React package and want to see changes reflected here, run `pnpm -F @molecule-ui/react build` first.
+- It consumes `@atomly-ai/react` as a dependency. If you change the React package and want to see changes reflected here, run `pnpm -F @atomly-ai/react build` first.
 - The site is not yet structured for production docs. When building out documentation pages, look at **Primer** (https://primer.style/) and **Atlassian Design System** (https://atlassian.design/) as references for how to structure component documentation pages.

--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -1,3 +1,3 @@
-# @molecule-ui/website
+# @atomly-ai/website
 
 Website to demo the components.

--- a/packages/website/next.config.ts
+++ b/packages/website/next.config.ts
@@ -1,8 +1,8 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   /* config options here */
-  transpilePackages: ['@molecule-ui/react']
+  transpilePackages: ['@atomly-ai/react'],
 };
 
 export default nextConfig;

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@molecule-ui/website",
+  "name": "@atomly-ai/website",
   "version": "0.0.2",
   "private": true,
   "scripts": {
@@ -9,7 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@molecule-ui/react": "workspace:*",
+    "@atomly-ai/react": "workspace:*",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/packages/website/src/app/page.tsx
+++ b/packages/website/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import Image from 'next/image';
 import styles from './page.module.css';
-import { Button } from '@molecule-ui/react';
+import { Button } from '@atomly-ai/react';
 
 export default function Home() {
   return (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,15 +74,15 @@ importers:
 
   packages/react:
     dependencies:
+      '@atomly-ai/types':
+        specifier: workspace:*
+        version: link:../types
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(@types/react@19.2.14)(react@19.2.4)
       '@emotion/styled':
         specifier: ^11.14.1
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
-      '@molecule-ui/types':
-        specifier: workspace:*
-        version: link:../types
       '@react-aria/button':
         specifier: ^3.14.4
         version: 3.14.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -179,7 +179,7 @@ importers:
 
   packages/vue:
     dependencies:
-      '@molecule-ui/types':
+      '@atomly-ai/types':
         specifier: workspace:*
         version: link:../types
     devDependencies:
@@ -243,7 +243,7 @@ importers:
 
   packages/website:
     dependencies:
-      '@molecule-ui/react':
+      '@atomly-ai/react':
         specifier: workspace:*
         version: link:../react
       next:
@@ -8358,7 +8358,7 @@ snapshots:
       eslint: 9.39.3(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.3(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.3(jiti@2.6.1))
@@ -8395,7 +8395,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.3(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -8429,7 +8429,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.3(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
## Summary

Renames the npm package scope across the monorepo from `@molecule-ui` to `@atomly-ai`, and sets up the first alpha release.

### Rename (`@molecule-ui/*` → `@atomly-ai/*`)
- Package names + `workspace:*` deps in all 5 `package.json` files (root renamed to `atomly-ai`)
- Imports in React source and the website
- Repository / homepage / bugs URLs → `recondesigns/atomly-ai`
- `.changeset/config.json` linked array, CI workflow filters, docs, and CHANGELOGs
- Regenerated `pnpm-lock.yaml`

### Release setup
- Entered changesets **alpha pre-release mode** (`.changeset/pre.json`)
- Added a changeset bumping `@atomly-ai/react`, `vue`, and `types` → **`0.2.0-alpha.0`**

### Scope note
Package identity only — the "Molecule UI" product name and code identifiers (`MoleculeProvider`, `MoleculeUITheme`) were intentionally left unchanged.

### Verification
- `pnpm build:types && pnpm build` — types → react → vue all pass
- Lockfile shows 0 remaining `@molecule-ui` references
- `pre-push` hook (typecheck + icon diff-check) passed