### PR TITLE
chore: exit changesets alpha pre-release mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "alpha",
   "initialVersions": {
     "@atomly-ai/react": "0.1.0",
@@ -7,8 +7,5 @@
     "@atomly-ai/vue": "0.1.0",
     "@atomly-ai/website": "0.0.2"
   },
-  "changesets": [
-    "color-palette-dark-mode",
-    "initial-atomly-ai-alpha"
-  ]
+  "changesets": ["color-palette-dark-mode", "initial-atomly-ai-alpha"]
 }

--- a/.claude/CHECKLIST.md
+++ b/.claude/CHECKLIST.md
@@ -141,8 +141,9 @@ Granular checklist for tooling, DX, and infrastructure work. Claude updates this
 - [x] `NPM_TOKEN` secret added to GitHub repo settings
 - [ ] `syncpack` installed to keep dependency versions consistent
 - [x] First alpha publish of `@atomly-ai/react` and `@atomly-ai/vue` (`0.2.0-alpha.0`, `alpha` dist-tag)
+- [x] Second alpha publish (`0.2.0-alpha.1`, color palette + dark mode). **Found a real npm dist-tag bug while verifying it published correctly:** `latest` pointed at `0.2.0-alpha.1` while `alpha` was frozen at `0.2.0-alpha.0` — backwards from intended. Root-caused to `@changesets/cli`'s own publish logic (`getReleaseTag`/`getUnpublishedPackages` in `changesets-cli.cjs.js`): while a package's `publishedState` is `"only-pre"` (every published version so far shares the pre-release tag, i.e. no "regular" release has ever happened), changesets deliberately publishes to `latest` instead of the configured tag — intentional, so `npm install` isn't stuck on the very first alpha forever. Consequence: the `alpha` tag can never move again, and every future alpha release would repeat the same "latest = newest alpha" pattern, for as long as pre-release mode continues.
 - [ ] Migrate release to npm Trusted Publishing (OIDC) — add `id-token: write` + npm ≥ 11.5.1 in `release.yml`, configure trusted publisher, then delete `NPM_TOKEN` secret
-- [ ] Exit changesets alpha pre-release mode (`pnpm changeset pre exit`) when ready for a stable release
+- [x] Exit changesets alpha pre-release mode (`pnpm changeset pre exit`, PR #51) — the actual fix for the dist-tag issue above, not a workaround: collapses the two accumulated alpha changesets into a single clean `0.2.0` (no prerelease suffix) on the next release, which correctly publishes to `latest` since it's a real release. Pre-release mode can be safely re-entered later (`pnpm changeset pre enter <tag>`, e.g. a `beta` phase before a future major) without hitting this same issue, since the `only-pre` condition only triggers when a package has _never_ had a regular release.
 
 ---
 


### PR DESCRIPTION
## Summary
- Exits changesets pre-release mode (`pnpm changeset pre exit`) so the next release publishes a plain, non-prerelease version instead of another `-alpha.N` build.

## Why
`@atomly-ai/react`/`vue`/`types` have only ever published prerelease (`alpha`) versions. Traced an npm dist-tag issue back to changesets' own publish logic: while a package has never had a "regular" release, changesets deliberately publishes to `latest` instead of the configured prerelease tag (`alpha`) — by design, so `npm install` isn't stuck on the first-ever alpha forever. Net effect: `latest` was tracking the newest alpha build while the `alpha` tag itself was frozen on the very first one, and every future alpha release would repeat this.

Exiting pre-release mode collapses the two accumulated alpha changesets into a single clean `0.2.0` release (no prerelease suffix) on the next version/publish cycle, which resolves this permanently — future releases go to `latest` correctly. Pre-release mode (e.g. a `beta` tag before some future major) can be re-entered later with `pnpm changeset pre enter <tag>` without hitting this issue again, since it only triggers when a package has *never* had a real release.

## Test plan
- [ ] `pnpm changeset pre exit` run locally — `.changeset/pre.json` mode flipped to `"exit"` (file itself is fully removed by the next automated `changeset version` run, not by this PR)
- [ ] `pnpm typecheck` and icon regeneration (pre-push hook) pass clean
- [ ] Next merge to `main` will trigger the changesets release PR — merging that publishes `0.2.0` to npm `latest`