### PR TITLE
chore: add Figma design link to Vue Button story

### DIFF
--- a/.claude/CHECKLIST.md
+++ b/.claude/CHECKLIST.md
@@ -200,7 +200,7 @@ Components are named `AlertIcon`, `CloseIcon`, etc. (noun + Icon suffix). SVG so
 ## Storybook Enhancements
 
 - [x] `@storybook/addon-designs` installed — embeds Figma frames in story panels. Added to both React and Vue Storybook configs (`addon-designs@11.1.3`, peer-compatible with our Storybook 10.2.10). Wired a `design` parameter on Button's story meta (using the Component Library file link from `.claude/specs/button.md`) as a working example — confirmed via Playwright screenshot that the "Design" tab appears and routes correctly in the addon panel. The embedded Figma iframe itself 403'd in the headless test browser (no Figma session/auth) — expected, since the file likely isn't set to public sharing; should render fine in an authenticated browser.
-- [ ] Figma frame links added to all existing stories (only Button has one so far, added as part of the above)
+- [ ] Figma frame links added to all existing stories — React: USER added node-scoped links (`?node-id=...`) to Button, Badge, and Chip. Vue: Button now has one too (reuses the same React Button frame — same component conceptually). Blocked on **ButtonGroup** and **Icons** — no Figma frames exist for them yet, so there's nothing to link to (a Figma-content gap, not a code gap). Vue's Badge/Chip don't exist yet either — only Button is built in `@atomly-ai/vue` so far.
 - [ ] Storybook deployed (Chromatic hosting or Vercel)
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -77,7 +77,7 @@ Build out the foundational atom and molecule set.
 ## Phase 4 — Quality & Design Collaboration
 
 - [x] Chromatic visual regression testing on all stories
-- [ ] `@storybook/addon-designs` (Figma frames embedded in Storybook)
+- [x] `@storybook/addon-designs` (Figma frames embedded in Storybook) — installed in both React and Vue. Frame links added to React's Button/Badge/Chip and Vue's Button; still missing on ButtonGroup and Icons (no Figma frames exist for them yet — a content gap, not a code one)
 - [ ] Figma Code Connect published for all core components (blocked — requires a paid Figma plan)
 - [x] Accessibility audit passing at WCAG 2.1 AA for all components (Vitest + Playwright + `@storybook/addon-a11y` set to `error`, 26/26 tests passing; a handful of pre-existing contrast bugs found and fixed along the way)
 - [ ] `size-limit` bundle size budgets in CI

--- a/packages/vue/src/atoms/button/Button.stories.ts
+++ b/packages/vue/src/atoms/button/Button.stories.ts
@@ -1,19 +1,24 @@
-
-import type { Meta, StoryObj } from '@storybook/vue3-vite'
-import { Button } from '.'
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import { Button } from '.';
 
 const meta = {
-    component: Button,
-    title: 'Test/Button',
-    tags: ['autodocs'],
-} satisfies Meta<typeof Button>
+  component: Button,
+  title: 'Test/Button',
+  tags: ['autodocs'],
+  parameters: {
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/design/wv7I1q5SbuPS4vozGd1gmR/Component-library?node-id=15-116&m=dev',
+    },
+  },
+} satisfies Meta<typeof Button>;
 
-export default meta
+export default meta;
 
-type ButtonStory = StoryObj<typeof meta>
+type ButtonStory = StoryObj<typeof meta>;
 
 export const Default: ButtonStory = {
-    args: {
-        label: 'Vue button',
-    },
-}
+  args: {
+    label: 'Vue button',
+  },
+};


### PR DESCRIPTION
## Summary
- Adds a `design` parameter to Vue's Button story, pointing at the same Figma Component Library frame used for React's Button (`node-id=15-116`) — same component conceptually, so the same frame link applies.

## Not included (per user confirmation)
- ButtonGroup and Icons don't have Figma frames yet, so there's nothing to link there — a Figma-content gap, not a code gap.
- Vue's Badge and Chip don't exist yet — only Button is built in `@atomly-ai/vue` so far.

## Test plan
- [ ] `pnpm lint` clean
- [ ] Vue `tsc --noEmit` clean
- [ ] `pnpm vitest run` in `packages/react` — 26/26 pass (unaffected by this change, run as a sanity check)