### PR TITLE
fix: exclude story and test files from published package output

### DIFF
--- a/.changeset/exclude-dev-files-from-dist.md
+++ b/.changeset/exclude-dev-files-from-dist.md
@@ -1,0 +1,6 @@
+---
+'@atomly-ai/react': patch
+'@atomly-ai/vue': patch
+---
+
+Excludes Storybook story files and unit test files from the published package's type declarations. `tsconfig.build.json` was compiling every file under `src` — including `*.stories.tsx` and `*.test.ts` — into `dist/**/*.d.ts`, leaking dev-only build artifacts (e.g. `dist/atoms/button/Button.stories.d.ts`) into the npm tarball. No runtime behavior changes; this only trims unnecessary files from the published package.

--- a/.claude/CHECKLIST.md
+++ b/.claude/CHECKLIST.md
@@ -149,6 +149,7 @@ Granular checklist for tooling, DX, and infrastructure work. Claude updates this
 
 ## Bundle Health
 
+- [x] Excluded `*.stories.tsx`/`*.test.ts` from `tsconfig.build.json` in React and Vue — these were leaking into the published npm tarball as `dist/**/*.stories.d.ts` / `dist/**/*.test.d.ts` (caught while explaining why recent Storybook-only PRs didn't need changesets). `tsconfig.build.json`'s `include: ["src"]` compiled every file under `src`, including dev-only ones; the base `tsconfig.json` used by `pnpm typecheck` is unaffected, so type-checking of stories/tests is unchanged. Verified via `npm pack --dry-run` before/after on both packages.
 - [ ] `size-limit` installed with per-package size budgets (`@atomly-ai/react`, `@atomly-ai/vue`)
 - [ ] Size limit check added to GitHub Actions CI (fails PR if budget exceeded)
 - [ ] `rollup-plugin-visualizer` added to Vite config for bundle composition inspection

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -5,5 +5,6 @@
     "declarationMap": true,
     "emitDeclarationOnly": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/*.stories.tsx", "**/*.stories.ts", "**/*.test.ts", "**/*.test.tsx"]
 }

--- a/packages/vue/tsconfig.build.json
+++ b/packages/vue/tsconfig.build.json
@@ -5,5 +5,6 @@
     "declarationMap": true,
     "emitDeclarationOnly": true
   },
-  "include": ["src", "src/**/*.vue"]
+  "include": ["src", "src/**/*.vue"],
+  "exclude": ["**/*.stories.tsx", "**/*.stories.ts", "**/*.test.ts", "**/*.test.tsx"]
 }


### PR DESCRIPTION
## Summary
- Surfaced while explaining why recent Storybook-focused PRs didn't need changesets — checked what actually ships in the npm tarball and found `dist/atoms/button/Button.stories.d.ts`, `dist/hooks/useButton.test.d.ts`, etc. leaking into both `@atomly-ai/react` and `@atomly-ai/vue`.
- Root cause: `tsconfig.build.json`'s `include: ["src"]` compiles every file under `src` into declaration output, including `*.stories.tsx` and `*.test.ts`. `package.json`'s `files: ["dist"]` then ships everything `tsc` emits, with no further filtering.
- Fix: added an `exclude` array to both packages' `tsconfig.build.json` for story and test file patterns.

## Impact
- `@atomly-ai/react`: 88 → 78 published files, 46,142 → 42,566 bytes unpacked
- `@atomly-ai/vue`: 34 → 30 published files, leaked story declarations removed
- No behavior change — `pnpm typecheck` (which uses the base `tsconfig.json`, not `tsconfig.build.json`) is unaffected, so stories/tests are still fully type-checked as before. This only trims the *published* declaration output.
- Changeset added (patch, both packages)

## Test plan
- [ ] `pnpm typecheck` clean
- [ ] `pnpm lint` clean
- [ ] `pnpm vitest run` in `packages/react` — 26/26 pass
- [ ] `npm pack --dry-run` on both packages confirms no `.stories.d.ts` / `.test.d.ts` files remain