### PR TITLE
chore: gitignore Claude Code local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ storybook-static/
 *.swp
 *.swo
 
+# Claude Code local settings
+.claude/settings.local.json
+
 # OS
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.local.json` to `.gitignore` so personal, machine-specific Claude Code config (e.g. a local hook that syncs `ROADMAP.md` to Notion on commit) never gets committed.

## Test plan
- [ ] Confirm `.claude/settings.local.json` is untracked by git after this change