### PR TITLE
docs: flatten component roadmap, add AI component entries

### DIFF
--- a/.claude/CHECKLIST.md
+++ b/.claude/CHECKLIST.md
@@ -178,15 +178,11 @@ Components are named `AlertIcon`, `CloseIcon`, etc. (noun + Icon suffix). SVG so
 
 ## Components
 
-### Atoms
-
 - [x] Button — `solid`, `outline`, `ghost` variants; `primary`, `success`, `danger`, `brand`, `warning` intents; `sm`/`md`/`lg` sizes; loading state; React Aria keyboard/press handling; light + dark theme support
 - [x] Badge — `filled` variant; `neutral`, `primary`, `success`, `danger`, `brand`, `warning` intents; `sm`/`md`/`lg` sizes; light + dark theme support
 - [x] Chip — `filled`, `outlined`, `ghost` variants; `neutral`, `primary`, `success`, `danger`, `warning` intents; `sm`/`md`/`lg` sizes; disabled state; token-backed colors from Token Studio; light + dark theme support
-
-### Molecules
-
-- [x] ButtonGroup — horizontal group wrapper for Button atoms
+- [ ] StatusDot — code implementation removed, restarting from scratch. Target shape unchanged: `neutral`/`primary`/`success`/`danger`/`warning` intents; `sm`/`md`/`lg` sizes; optional `breathing`/`tool-calling` animations (Figma component library, node 88:104). Figma-side work (component + variant descriptions, designer/developer documentation frames, and the new `color/background/{intent}-alpha-20/-40` semantic tokens in the Design Tokens file) remains valid and is not being redone.
+- [x] ButtonGroup — horizontal group wrapper for Button
 
 ### Planned
 
@@ -195,7 +191,6 @@ Components are named `AlertIcon`, `CloseIcon`, etc. (noun + Icon suffix). SVG so
 - [ ] Toggle / Switch
 - [ ] Checkbox
 - [ ] Avatar
-- [ ] StatusDot — small colored dot indicating status (online/offline/away, or intent-based)
 
 ---
 

--- a/.claude/CHECKLIST.md
+++ b/.claude/CHECKLIST.md
@@ -195,6 +195,7 @@ Components are named `AlertIcon`, `CloseIcon`, etc. (noun + Icon suffix). SVG so
 - [ ] Toggle / Switch
 - [ ] Checkbox
 - [ ] Avatar
+- [ ] StatusDot — small colored dot indicating status (online/offline/away, or intent-based)
 
 ---
 

--- a/.claude/specs/color-palette.md
+++ b/.claude/specs/color-palette.md
@@ -73,6 +73,16 @@ amber ramp has no third dark step).
 | ---- | --------- | --------- | --------- | --------- | --------- | --------- | --------- | --------- | --------- | --------- | --------- |
 | Hex  | `#fef2f2` | `#fee2e2` | `#fecaca` | `#fca5a5` | `#f87171` | `#ef4444` | `#dc2626` | `#b91c1c` | `#991b1b` | `#7f1d1d` | `#450a0a` |
 
+### Blue — `info` (net-new, added 2026-07-09)
+
+Revived rather than removed — see the resolved open question below. Same Tailwind-standard
+blue scale this repo used for `primary` before the indigo migration (600 step is the exact
+`#2563eb` the old hardcoded focus-ring used).
+
+| Step | 50        | 100       | 200       | 300       | 400       | 500       | 600 ★     | 700       | 800       | 900       | 950       |
+| ---- | --------- | --------- | --------- | --------- | --------- | --------- | --------- | --------- | --------- | --------- | --------- |
+| Hex  | `#eff6ff` | `#dbeafe` | `#bfdbfe` | `#93c5fd` | `#60a5fa` | `#3b82f6` | `#2563eb` | `#1d4ed8` | `#1e40af` | `#1e3a8a` | `#172554` |
+
 ### Unchanged
 
 - **neutral** 0–1200 (slate + navy-tinted deep end) — the deep 1000–1200 steps are the dark
@@ -88,19 +98,21 @@ amber ramp has no third dark step).
 
 ## Semantic re-aliasing highlights
 
-| Semantic token                                                                            | Today                     | Becomes                                              |
-| ----------------------------------------------------------------------------------------- | ------------------------- | ---------------------------------------------------- |
-| `background/primary` (+hover/active/subtle)                                               | `blue.600/700/800/100`    | `indigo.600/700/800/50`                              |
-| `background/brand` (+hover/subtle)                                                        | `amber.500/600/100`       | `coral.500/600/50`; add `brand-active` → `coral.700` |
-| `background/thinking`, `border/thinking`                                                  | `blue.100`, `blue.400`    | `violet.100`, `violet.400`                           |
-| `background/success` (+subtle)                                                            | `green.600/50`            | `emerald.600/50`                                     |
-| `text/primary`, `border/focused`, `icon/primary`                                          | `blue.600`                | `indigo.600`                                         |
-| `text/brand`, `icon/brand`                                                                | `amber.600` / `amber.500` | `coral.600` / `coral.500`                            |
-| `text/success`, `border/success`, `icon/success`                                          | `green.600`               | `emerald.600`                                        |
-| `focus-ring`                                                                              | `#2563eb66` (blue @ 40%)  | indigo @ 40% (`#4f46e566`)                           |
-| `surface/user`                                                                            | `blue.100`                | `indigo.50`                                          |
-| **New:** `background/warning` (+subtle), `text/warning`, `border/warning`, `icon/warning` | —                         | alias `amber.*`                                      |
-| **Dark mode `*-subtle` backgrounds**                                                      | reuse light steps         | alias the new `950` steps                            |
+| Semantic token                                                                            | Today                     | Becomes                                                                          |
+| ----------------------------------------------------------------------------------------- | ------------------------- | -------------------------------------------------------------------------------- |
+| `background/primary` (+hover/active/subtle)                                               | `blue.600/700/800/100`    | `indigo.600/700/800/50`                                                          |
+| `background/brand` (+hover/subtle)                                                        | `amber.500/600/100`       | `coral.500/600/50`; add `brand-active` → `coral.700`                             |
+| `background/thinking`, `border/thinking`                                                  | `blue.100`, `blue.400`    | `violet.100`, `violet.400`                                                       |
+| `background/success` (+subtle)                                                            | `green.600/50`            | `emerald.600/50`                                                                 |
+| `text/primary`, `border/focused`, `icon/primary`                                          | `blue.600`                | `indigo.600`                                                                     |
+| `text/brand`, `icon/brand`                                                                | `amber.600` / `amber.500` | `coral.600` / `coral.500`                                                        |
+| `text/success`, `border/success`, `icon/success`                                          | `green.600`               | `emerald.600`                                                                    |
+| `focus-ring`                                                                              | `#2563eb66` (blue @ 40%)  | indigo @ 40% (`#4f46e566`)                                                       |
+| `surface/user`                                                                            | `blue.100`                | `indigo.50`                                                                      |
+| **New:** `background/warning` (+subtle), `text/warning`, `border/warning`, `icon/warning` | —                         | alias `amber.*`                                                                  |
+| **New:** `background/info` (+subtle), `text/info`, `border/info`, `icon/info`             | —                         | alias `blue.*` — same shape as `success`/`warning` (no hover/active)             |
+| **New:** `background/ai` (+subtle), `text/ai`, `border/ai`, `icon/ai`                     | —                         | alias `violet.*` — additive to the existing `thinking` tokens, not a replacement |
+| **Dark mode `*-subtle` backgrounds**                                                      | reuse light steps         | alias the new `950` steps                                                        |
 
 ## Impact on code (do not change until Figma + sync are done)
 
@@ -124,6 +136,17 @@ amber ramp has no third dark step).
 
 - **Coral vs terracotta:** proposed coral anchors on `#f97316`; the softer Claude-like
   alternative anchors on `#d97757`. Decision: trying coral first (2026-07-05).
-- Should `blue` survive as an `info` ramp, or is indigo+violet enough? (Proposal: remove.)
+- ~~Should `blue` survive as an `info` ramp, or is indigo+violet enough? (Proposal: remove.)~~
+  **Resolved (2026-07-09): kept.** Revived as a full `info` intent (`background`/`text`/`border`/`icon`,
+  same shape as `success`/`warning` — no hover/active) — matches Atlassian/Polaris/Carbon/Fluent,
+  all of which keep a semantic tone distinct from primary for neutral/informational messaging.
 - Does `warning` become a full component intent (Button/Badge/Chip) or semantic-only for now?
+  Still semantic-only — `info` follows the same precedent (2026-07-09): semantic tokens land
+  first, component-intent promotion (Button/Badge/Chip unions) is a separate later decision.
 - Cover-page stats in Figma ("186 Tokens") are already stale — update after the overhaul.
+- **AI moments beyond thinking (2026-07-09):** `background/thinking` and `border/thinking`
+  already existed (aliased to violet). Added `background/ai` (+subtle), `text/ai`, `border/ai`,
+  `icon/ai` as a general AI-accent intent (assistant labels, "AI" badges, generated-content
+  indicators) — distinct from the streaming-specific `thinking` tokens, both alias `violet.*`.
+  Not yet in scope: role-based chat surface tokens (user vs. assistant bubble background),
+  exposing the full neutral scale through `MoleculeUITheme`, and Vue theme-consumption parity.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@ Get the core infrastructure solid before building out the component library.
 - [x] Husky + commitlint + lint-staged
 - [x] GitHub Actions CI pipeline (lint → build → test)
 - [x] Changesets for monorepo versioning
-- [x] First npm publish (alpha, later exited pre-release mode for a clean `0.2.0`)
+- [x] First npm publish (alpha, later exited pre-release mode for a clean `0.2.0`, re-entered alpha while Phase 3 buildout continues)
 
 ---
 
@@ -56,6 +56,7 @@ Build out the foundational atom and molecule set.
 - [ ] Spinner / Loader
 - [ ] Tooltip
 - [ ] Divider
+- [ ] StatusDot
 
 **Molecules**
 
@@ -87,6 +88,8 @@ Build out the foundational atom and molecule set.
 
 ## Phase 5 — Documentation Site
 
+- [x] Site-only `Button` component for website chrome (built from Figma "Website" file, node 43:538) — not part of `@atomly-ai/react`
+- [x] Emotion SSR cache registry (`EmotionRegistry`) wired into the root layout — fixes a hydration mismatch from missing `useServerInsertedHTML` setup
 - [ ] Documentation site structure (`packages/website`)
 - [ ] Component pages with live examples, props table, usage guidelines
 - [ ] Design token reference page

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,14 +34,13 @@ Establish the design token pipeline so components are tied to Figma.
 - [ ] Token documentation in Storybook
 - [x] AI-native color palette redesign — indigo primary, violet AI accent, coral brand, amber promoted to a full `warning` intent, emerald success (see `.claude/specs/color-palette.md`)
 - [x] Dark mode theming layer — `colorDark` token block sourced from Figma's `Color/Dark` collection, `darkTheme` export, `MoleculeProvider` `colorScheme` prop, Storybook light/dark toggle
+- [ ] Sync new `color/background/{intent}-alpha-20` / `-alpha-40` semantic variables (added directly in the Design Tokens Figma file, 8 intents × 2 alpha steps) through `tokens/figma-export.json` → `sync-figma-tokens.mjs`, and update `.claude/specs/color-palette.md` to document them — planned for a separate branch
 
 ---
 
 ## Phase 3 — Core Component Library (current)
 
-Build out the foundational atom and molecule set.
-
-**Atoms**
+Build out the foundational component set.
 
 - [x] Button (`solid`/`outline`/`ghost`; `primary`/`success`/`danger`/`brand`/`warning` intents)
 - [x] Badge (`filled`; `neutral`/`primary`/`success`/`danger`/`brand`/`warning` intents)
@@ -56,10 +55,11 @@ Build out the foundational atom and molecule set.
 - [ ] Spinner / Loader
 - [ ] Tooltip
 - [ ] Divider
-- [ ] StatusDot
-
-**Molecules**
-
+- [ ] StatusDot — code implementation removed, restarting from scratch. Target shape unchanged: `neutral`/`primary`/`success`/`danger`/`warning` intents; `sm`/`md`/`lg` sizes; optional `breathing`/`tool-calling` animations (Figma component library, node 88:104)
+- [ ] AI Label — based on Carbon Design System's AI Label component; small badge marking AI-generated/AI-assisted content, opens a popover on interaction that explains what the AI did and why (depends on the planned Popover molecule below)
+- [ ] AIButton — needs research; likely a Button variant that composes the AI Label pattern (Carbon-style)
+- [ ] AIBadge — needs research; likely a Badge variant that composes the AI Label pattern
+- [ ] AITextField — needs research; likely a text input variant that composes the AI Label pattern
 - [x] ButtonGroup
 - [ ] FormField (label + input + error)
 - [ ] Modal / Dialog
@@ -95,7 +95,9 @@ Build out the foundational atom and molecule set.
 - [ ] Design token reference page
 - [ ] Getting started / installation guide
 - [ ] Contribution guide
-- [ ] Changelog page (driven by Changesets)
+- [ ] Changelog infrastructure (sourced from Changesets), surfaced in two places:
+  - [ ] Website changelog page
+  - [ ] Per-package changelog in each Storybook — React's Storybook shows only `@atomly-ai/react` changes, Vue's shows only `@atomly-ai/vue` changes (not a combined feed)
 
 ---
 


### PR DESCRIPTION
## Summary
- Flatten ROADMAP.md / CHECKLIST.md component lists — drop the Atoms/Molecules subheadings in favor of one combined list
- Add AI Label, AIButton, AIBadge, and AITextField as planned components (AI Label based on Carbon Design System's AI Label component, with a popover explaining AI reasoning; the other three still need research)
- Note StatusDot's restart status — code implementation was removed and is being rebuilt from scratch; target shape and Figma-side work are unchanged and documented
- Document the revived `info` ramp and new `ai` accent intent in `color-palette.md`, resolving the two related open questions

## Test plan
- [ ] Docs-only change — confirm ROADMAP.md and CHECKLIST.md render correctly and the flattened component lists read cleanly
